### PR TITLE
chose: add Nix and Direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# Use nix
+use nix
+
+# Warn if the shell is idle for more than 1 minute
+export DIRENV_WARN_TIMEOUT=1m

--- a/README.md
+++ b/README.md
@@ -218,6 +218,24 @@ No error handling yet.
 
 ## Contributing
 
+### Nix Setup (Recommended)
+
+1. Install [Nix](https://nixos.org/nix/)
+
+   ```
+   sh <(curl -L https://nixos.org/nix/install)
+   ```
+
+2. Install and setup [Direnv](https://direnv.net/)
+
+   ```
+   # Install direnv
+   curl -sfL https://direnv.net/install.sh | bash
+
+   # Load nix environment
+   direnv allow
+   ```
+
 ### VS Code Dev Container Setup (Optional)
 
 Project includes DevContainer configuration for consistent development environment:

--- a/shell.nix
+++ b/shell.nix
@@ -22,12 +22,8 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    export DIRENV_LOG_FORMAT=""
-    
     python -m venv .venv
     source .venv/bin/activate
-    
-    export PIP_QUIET=1
 
     # Install all dependencies from requirements.txt
     pip install --upgrade pip --quiet

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,36 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    python312
+    nodejs_20
+    rustc
+    cargo
+    awscli2
+    docker
+    zsh
+    oh-my-zsh
+    git
+    black
+    
+    # Only core Python packages needed for bootstrapping
+    (python312.withPackages (ps: with ps; [
+      pip
+      setuptools
+      wheel
+    ]))
+  ];
+
+  shellHook = ''
+    export DIRENV_LOG_FORMAT=""
+    
+    python -m venv .venv
+    source .venv/bin/activate
+    
+    export PIP_QUIET=1
+
+    # Install all dependencies from requirements.txt
+    pip install --upgrade pip --quiet
+    pip install -r ./agent/requirements.txt --upgrade --quiet
+  '';
+}


### PR DESCRIPTION
## Description

This PR aims to simplify our local setup. by applying all needed packages once we are inside the `bot-new/` directory.

It adds support for both `nix` and `direnv`.

## Test Plan

Tested this by cloning the `bot-new` repo, running `direnv allow` and simply running the contents of the `ApplicationTest.ipynb` notebook.

https://github.com/user-attachments/assets/5b5023a9-d61d-4ae9-a1f0-cc2f0a51b79c

