### PR TITLE
fix: don't allow primitive types in handlers arguments

### DIFF
--- a/agent/policies/typespec.py
+++ b/agent/policies/typespec.py
@@ -24,6 +24,7 @@ Rules:
 - Each function in the interface should be decorated with at least one @scenario decorator.
 - Each function must have a complete set of scenarios defined with @scenario decorator.
 - Each function should have a single argument "options".
+- The "options" parameter must always be an object model type, never a primitive type.
 - Data model for the function argument should be simple and easily inferable from chat messages.
 - Using reserved keywords for property names, type names, and function names is not allowed.
 

--- a/agent/prepare_containers.sh
+++ b/agent/prepare_containers.sh
@@ -1,2 +1,3 @@
-docker build -t botbuild/tsp_compiler -f Dockerfile.typespec .
-docker build -t botbuild/app_schema -f Dockerfile.application .
+SCRIPT_DIR=$(dirname "$0")
+docker build -t botbuild/tsp_compiler -f ${SCRIPT_DIR}/Dockerfile.typespec ${SCRIPT_DIR}
+docker build -t botbuild/app_schema -f ${SCRIPT_DIR}/Dockerfile.application ${SCRIPT_DIR}

--- a/agent/templates/tsp_schema/helpers.js
+++ b/agent/templates/tsp_schema/helpers.js
@@ -1,3 +1,44 @@
-export function $llm_func(target, description) {}
+export function $llm_func(context, target, description) {
+  const properties = target.parameters.node.properties;
+  const property = properties[0];
+
+  // get the fnHandler argument type
+  const fnArgumentType = property.value.target.sv;
+
+  // typespec models available
+  const modelsMap = target.namespace.models;
+  const keysIterator = modelsMap.keys();
+  const keysArray = Array.from(keysIterator);
+
+  // check if the argument type is a complex model type
+  // else, report an error
+  // we can't JSONify primitive types
+  if (!keysArray.includes(fnArgumentType)) {
+    context.program.reportDiagnostic({
+      code: 'llm-func-invalid-argument',
+      target: property.value.target,
+      messageId: 'invalidArgument',
+      severity: 'error',
+      message: `
+       Function '${target.name}' must use a complex model type as argument, found '${fnArgumentType}' instead.
+       Extract the argument type into a model and use it as the argument type.
+
+       <wrong-example>
+        @llm_func(1)
+        fnHandler(args: utcDateTime): void;
+       </wrong-example>
+
+       <correct-example>
+        model ArgumentsModelName {
+            date: utcDateTime;
+        }
+            
+        @llm_func(1)
+        fnHandler(args: ArgumentsModelName): void;
+       </correct-example>
+      `,
+    });
+  }
+}
 
 export function $scenario(target, gherkin) {}


### PR DESCRIPTION
## Description

This PR aims to fix an issue in the generated TypeSpec that occasionally generated handlers whose arguments were primitive types (e.g. `date`). However, the handler argument needs to be a complex object (a TSP Model), so we can parse it and transform it into JSON.

**FIX**

- Provided an extra line to the prompt, to make sure this occurs way less often;
- Through some TSP decorator reflection, throw a compilation error if this occurs;


## Test Plan

Tested this fix by forcing the generation of these "bugged" handlers and looked at the Traces to understand how the bot would react in the next iterations.

Example tracing: https://cloud.langfuse.com/project/cm6j91sap009ux891llzvdjvi/traces/8d70aaf4-d656-4aaa-b09e-332a03bec9a9?timestamp=2025-02-25T17%3A20%3A11.295Z

![image](https://github.com/user-attachments/assets/ab7d8ea3-45d9-4aff-8591-a98b092220f3)

