### PR TITLE
Add validation for void return types in LLM functions

### DIFF
--- a/agent/templates/tsp_schema/helpers.js
+++ b/agent/templates/tsp_schema/helpers.js
@@ -27,7 +27,7 @@ export function $llm_func(context, target, description) {
 
        <correct-example>
         @llm_func(1)
-        fnHandler(args: ArgumentsModel): string;
+        fnHandler(args: ArgumentsModel): boolean;
        </correct-example>
       `,
     });

--- a/agent/templates/tsp_schema/helpers.js
+++ b/agent/templates/tsp_schema/helpers.js
@@ -10,6 +10,29 @@ export function $llm_func(context, target, description) {
   const keysIterator = modelsMap.keys();
   const keysArray = Array.from(keysIterator);
 
+  // Check if the return type is void
+  if (target.returnType && target.returnType.kind === "Intrinsic" && target.returnType.name === "void") {
+    context.program.reportDiagnostic({
+      code: 'llm-func-void-return',
+      target: target,
+      messageId: 'voidReturn',
+      severity: 'error',
+      message: `
+       Function '${target.name}' must return a non-void value.
+       
+       <wrong-example>
+        @llm_func(1)
+        fnHandler(args: ArgumentsModel): void;
+       </wrong-example>
+
+       <correct-example>
+        @llm_func(1)
+        fnHandler(args: ArgumentsModel): string;
+       </correct-example>
+      `,
+    });
+  }
+
   // check if the argument type is a complex model type
   // else, report an error
   // we can't JSONify primitive types


### PR DESCRIPTION
This update introduces a check in the $llm_func helper to ensure that functions declared with a void return type are flagged as errors. The diagnostic message provides examples of incorrect and correct usage to guide developers in adhering to the expected return type conventions.