### PR TITLE
Fix: Address Docker build failure for ARM64

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -266,6 +266,9 @@ jobs:
         with:
           registry: ${{ env.ECR_REGISTRY }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Build and push Docker image to ECR
         if: steps.check_release.outputs.is_release == 'true'
         working-directory: ./agent/

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.3 AS prod
+FROM --platform=linux/arm64 alpine:3.21.3 AS prod
 
 RUN apk add --update --no-cache curl python3 docker
 COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /uvx /bin/


### PR DESCRIPTION
The Docker build for the 'prod' target was failing with an "exec format error" when trying to run `apk add` commands. This typically indicates an issue with architecture compatibility when building for ARM64.

This commit addresses the issue by:
1. Explicitly specifying `--platform=linux/arm64` for the `alpine:3.21.3` base image in the `agent/Dockerfile`. This ensures that Docker pulls the correct architecture for the base image.
2. Adding a QEMU setup step (`docker/setup-qemu-action@v3`) to the `build-and-push` job in the `.github/workflows/pipeline.yml`. This ensures that the GitHub Actions runner is properly configured for ARM64 emulation during the Docker build process.

These changes aim to resolve the build errors and ensure the CI pipeline can successfully build and push the ARM64 Docker image.