### PR TITLE
add frontend linter

### DIFF
--- a/agent/trpc_agent/template/client/eslint.config.js
+++ b/agent/trpc_agent/template/client/eslint.config.js
@@ -4,6 +4,35 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
+const noEmptySelectValue = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow empty string values in Select.Item components',
+    },
+    messages: {
+      emptySelectValue: 'Select.Item value prop cannot be an empty string',
+    },
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (
+          node.name?.name === 'value' &&
+          node.parent?.name?.name === 'Select.Item' &&
+          node.value?.type === 'Literal' &&
+          node.value.value === ''
+        ) {
+          context.report({
+            node,
+            messageId: 'emptySelectValue',
+          });
+        }
+      },
+    };
+  },
+};
+
 export default tseslint.config(
   { ignores: ['dist'] },
   {
@@ -16,6 +45,11 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'custom': {
+        rules: {
+          'no-empty-select-value': noEmptySelectValue,
+        },
+      },
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
@@ -23,6 +57,13 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      'custom/no-empty-select-value': 'error',
+    },
+  },
+  {
+    files: ['**/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
     },
   },
 )

--- a/agent/trpc_agent/utils.py
+++ b/agent/trpc_agent/utils.py
@@ -89,6 +89,11 @@ class RunFrontendBuild:
         if result.exit_code != 0:
             err = self.build_output_normalizer.sub("", result.stderr)
             return f"Build errors:\n{err}\n"
+
+        result = await node.data.workspace.exec(["bun", "run", "lint"], cwd="client")
+        if result.exit_code != 0:
+            return f"Lint errors:\n{result.stdout}\n"
+
         return None
 
 run_frontend_build = RunFrontendBuild()


### PR DESCRIPTION
This new rule is supposed to fix problems like: 
```
Uncaught Error: A <Select.Item /> must have a value prop that is not an empty string. This is because the Select value can be set to an empty string to clear the selection and show the placeholder.
```