### PR TITLE
Feat/template support of custom agent templates

### DIFF
--- a/agent/api/agent_server/agent_api.tsp
+++ b/agent/api/agent_server/agent_api.tsp
@@ -158,6 +158,9 @@ model AgentRequest {
   @doc("Unique identifier for this request/response cycle.")
   traceId: string;
 
+  @doc("Unique identifier of the template the agent supports.")
+  templateId?: string;
+
   @doc("The full state of the Agent Server to restore from.")
   agentState?: Record<string, unknown> | null;
 
@@ -189,6 +192,7 @@ interface MessageOperations {
   - allMessages: [str] - history of all user messages
   - applicationId: str - required for Agent Server for tracing
   - traceId: str - required - a string used in SSE events
+  - templateId: str - optional an ID of the template to use in the agent
   - agentState: {..} or null - the full state of the Agent to restore from
   - settings: {...} - json with settings with number of iterations etc
 

--- a/agent/api/agent_server/agent_api_client.py
+++ b/agent/api/agent_server/agent_api_client.py
@@ -389,7 +389,7 @@ def get_all_files_from_project_dir(project_dir_path: str) -> List[FileEntry]:
     return local_files
 
 
-async def run_chatbot_client(host: str, port: int, state_file: str, settings: Optional[str] = None, autosave=False) -> None:
+async def run_chatbot_client(host: str, port: int, state_file: str, settings: Optional[str] = None, autosave=False, template_id: Optional[str] = None) -> None:
     """
     Async interactive Agent CLI chat.
     """
@@ -894,6 +894,7 @@ async def run_chatbot_client(host: str, port: int, state_file: str, settings: Op
                             content,
                             all_files=all_files_payload, # Pass the files
                             settings=settings_dict,
+                            template_id=template_id,
                             auth_token=auth_token,
                             stream_cb=print_event
                         )
@@ -973,12 +974,13 @@ def spawn_local_server(command: List[str] = ["uv", "run", "server"], host: str =
 def cli(host: str = "",
         port: int = 8001,
         state_file: str = "/tmp/agent_chat_state.json",
+        template_id: Optional[str] = None,
         ):
     if not host:
         with spawn_local_server() as (local_host, local_port):
-            anyio.run(run_chatbot_client, local_host, local_port, state_file, backend="asyncio")
+            anyio.run(run_chatbot_client, local_host, local_port, state_file, template_id=template_id, backend="asyncio")
     else:
-        anyio.run(run_chatbot_client, host, port, state_file, backend="asyncio")
+        anyio.run(run_chatbot_client, host, port, state_file, template_id=template_id, backend="asyncio")
 
 
 if __name__ == "__main__":

--- a/agent/api/agent_server/agent_client.py
+++ b/agent/api/agent_server/agent_client.py
@@ -49,6 +49,7 @@ class AgentApiClient:
                           trace_id: Optional[str] = None,
                           agent_state: Optional[Dict[str, Any]] = None,
                           all_files: Optional[List[Dict[str, str]]] = None,
+                          template_id: Optional[str] = None,
                           settings: Optional[Dict[str, Any]] = None,
                           auth_token: Optional[str] = CONFIG.builder_token,
                           stream_cb: Optional[Callable[[AgentSseEvent], None]] = None
@@ -57,7 +58,7 @@ class AgentApiClient:
         """Send a message to the agent and return the parsed SSE events"""
 
         if request is None:
-            request = self.create_request(message, messages_history, application_id, trace_id, agent_state, all_files, settings)
+            request = self.create_request(message, messages_history, application_id, trace_id, agent_state, all_files, template_id, settings)
         else:
             logger.info(f"Using existing request with trace ID: {request.trace_id}, ignoring some parameters like message, all_files")
             if all_files is not None:
@@ -134,7 +135,8 @@ class AgentApiClient:
                      trace_id: Optional[str] = None,
                      agent_state: Optional[Dict[str, Any]] = None,
                      all_files: Optional[List[Dict[str, str]]] = None,
-                     settings: Optional[Dict[str, Any]] = None) -> AgentRequest:
+                     template_id: Optional[str] = None,
+                     settings: Optional[Dict[str, Any]] = None)  -> AgentRequest:
         """Create a request object for the agent API"""
 
         all_messages_list = list(messages_history) if messages_history else []
@@ -150,6 +152,7 @@ class AgentApiClient:
             traceId=trace_id or uuid.uuid4().hex,
             agentState=agent_state,
             allFiles=file_entries,
+            templateId=template_id,
             settings=settings or {"max-iterations": 3}
         )
 

--- a/agent/api/agent_server/models.py
+++ b/agent/api/agent_server/models.py
@@ -147,6 +147,7 @@ class AgentRequest(BaseModel):
     application_id: str = Field(..., alias="applicationId", description="Unique identifier for the application instance.")
     trace_id: str = Field(..., alias="traceId", description="Unique identifier for this request/response cycle.")
     all_files: Optional[List[FileEntry]] = Field(None, alias="allFiles", description="All files in the workspace to be used for diff generation.")
+    template_id: Optional[str] = Field(None, alias="templateId", description="Unique identifier of the template the agent supports.")
     agent_state: Optional[Dict[str, Any]] = Field(
         None, 
         alias="agentState", 

--- a/agent/api/agent_server/test_api_server.py
+++ b/agent/api/agent_server/test_api_server.py
@@ -81,3 +81,16 @@ async def test_external_server_message():
             print(f"Successfully tested external server at {external_server_url}")
         except Exception as e:
             pytest.fail(f"Error testing external server: {e}")
+
+
+async def test_template_id_support(client):
+    """Test that templateId field is properly handled in requests."""
+    # Test with default template (None)
+    events, request = await client.send_message("Hello", template_id=None)
+    assert len(events) > 0, "No events received with default template"
+    assert request.template_id is None, "Template ID should be None by default"
+    
+    # Test with specific template ID
+    events, request = await client.send_message("Hello", template_id="trpc_agent")
+    assert len(events) > 0, "No events received with specific template"
+    assert request.template_id == "trpc_agent", "Template ID should match requested value"

--- a/agent/api/config.py
+++ b/agent/api/config.py
@@ -21,5 +21,22 @@ class Config:
     def snapshot_bucket(self):
         return os.getenv("SNAPSHOT_BUCKET", None)
 
+    @property
+    def available_templates(self):
+        """List of all available template IDs"""
+        return ["trpc_agent"]
+
+    @property
+    def default_template_id(self):
+        """Default template ID to use when none is specified"""
+        return os.getenv("DEFAULT_TEMPLATE_ID", "trpc_agent")
+
+    @property
+    def template_paths(self):
+        """Mapping of template IDs to their filesystem paths"""
+        return {
+            "trpc_agent": "trpc_agent/template"
+        }
+
 
 CONFIG = Config()

--- a/agent/commands.py
+++ b/agent/commands.py
@@ -67,12 +67,12 @@ def generate():
     return Fire(_generate)
 
 
-def _generate(prompt=None):
+def _generate(prompt=None, template_id=None):
     from tests.test_e2e import run_e2e, DEFAULT_APP_REQUEST
     coloredlogs.install(level="INFO")
     if prompt is None:
         prompt = DEFAULT_APP_REQUEST
-    anyio.run(run_e2e, prompt, True)
+    anyio.run(run_e2e, prompt, True, template_id)
 
 
 def interactive():

--- a/agent/tests/test_e2e.py
+++ b/agent/tests/test_e2e.py
@@ -47,11 +47,11 @@ def latest_app_name_and_commit_message(events):
 
     return app_name, commit_message
 
-async def run_e2e(prompt: str, standalone: bool, with_edit=True):
+async def run_e2e(prompt: str, standalone: bool, with_edit=True, template_id=None):
     context = empty_context() if standalone else spawn_local_server()
     with context:
         async with AgentApiClient() as client:
-            events, request = await client.send_message(prompt)
+            events, request = await client.send_message(prompt, template_id=template_id)
             assert events, "No response received from agent"
             while events[-1].message.kind == MessageKind.REFINEMENT_REQUEST:
                 events, request = await client.continue_conversation(


### PR DESCRIPTION
  Usage Examples

  # Default template
  uv run generate --prompt="Build a counter app"
  uv run interactive

  # Specific template  
  uv run generate --template_id="trpc_agent" --prompt="Build a todo app"
  uv run interactive --template_id="trpc_agent"

  # Check available templates
  curl http://localhost:8001/templates

  The implementation maintains full backward compatibility while providing the foundation for multiple template
  support.