### PR TITLE
fix: migrations that require interaction with CLI

### DIFF
--- a/agent/trpc_agent/template/Dockerfile
+++ b/agent/trpc_agent/template/Dockerfile
@@ -58,4 +58,4 @@ COPY supervisord.conf /etc/supervisord.conf
 
 EXPOSE ${SERVER_PORT} 80
 
-CMD ["sh", "-c", "bun db:push && /usr/bin/supervisord -c /etc/supervisord.conf"]
+CMD ["sh", "-c", "bun db:push-ci && /usr/bin/supervisord -c /etc/supervisord.conf"]

--- a/agent/trpc_agent/template/package.json
+++ b/agent/trpc_agent/template/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "db:push": "bun run --filter app-build-server db:push",
+    "db:push-ci": "bun run --filter app-build-server db:push-ci",
     "dev:server": "bun run --filter app-build-server dev",
     "dev:client": "bun run --filter app-build-client dev",
     "dev:all": "bun run dev:server & bun run dev:client"

--- a/agent/trpc_agent/template/server/package.json
+++ b/agent/trpc_agent/template/server/package.json
@@ -5,6 +5,7 @@
     "build": "tsc",
     "dev": "bun --hot src/index.ts",
     "db:push": "drizzle-kit push --force",
+    "db:push-ci": "printf '\\e[B\\r' | bun db:push",
     "lint": "eslint --cache src/index.ts"
   },
   "dependencies": {

--- a/agent/trpc_agent/template/server/package.json
+++ b/agent/trpc_agent/template/server/package.json
@@ -5,7 +5,7 @@
     "build": "tsc",
     "dev": "bun --hot src/index.ts",
     "db:push": "drizzle-kit push --force",
-    "db:push-ci": "printf '\\e[B\\r' | bun db:push",
+    "db:push-ci": "yes $'\\e[B\\r' | bun db:push",
     "lint": "eslint --cache src/index.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

This PR aims to fix an issue for DB migrations that require some sort of interaction in the CLI. The fix is kinda hacky, as it just uses the first option everytime, but should do for the time being. 

The "optimal fix" would need to envolve the agent to actually select the proper CLI option and generate migrations file, according to what was actually done. cc @igrekun 
