### PR TITLE
Disable Dagger telemtry

### DIFF
--- a/agent/api/agent_server/async_server.py
+++ b/agent/api/agent_server/async_server.py
@@ -18,8 +18,14 @@ from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import uvicorn
 from fire import Fire
-import dagger
 import os
+# Disable dagger telemetry
+os.environ["DO_NOT_TRACK"] = "1"
+os.environ["OTEL_TRACES_EXPORTER"] = "none"
+os.environ["OTEL_METRICS_EXPORTER"] = "none"
+os.environ["OTEL_LOGS_EXPORTER"] = "none"
+
+import dagger
 import json
 from brotli_asgi import BrotliMiddleware
 from dotenv import load_dotenv


### PR DESCRIPTION
PR Explanation: Fix Dagger OpenTelemetry Configuration Error

  Problem

  The application was failing to start with a RuntimeError: Requested component 'otlp_proto_grpc' not found in entry point 'opentelemetry_traces_exporter' error when initializing Dagger connections.

  Root Cause

  - Dagger-io (v0.18.9) has a dependency on OpenTelemetry packages for telemetry collection
  - It specifically requires opentelemetry-exporter-otlp-proto-http but internally tries to use the gRPC exporter
  - The gRPC exporter package (opentelemetry-exporter-otlp-proto-grpc) is not installed, causing the initialization failure

  Solution

  Since telemetry is not used in this project, we disabled it entirely by setting environment variables before importing Dagger:

  os.environ["DO_NOT_TRACK"] = "1"                # Standard telemetry opt-out
  os.environ["OTEL_TRACES_EXPORTER"] = "none"     # Disable trace exporting
  os.environ["OTEL_METRICS_EXPORTER"] = "none"    # Disable metrics exporting  
  os.environ["OTEL_LOGS_EXPORTER"] = "none"       # Disable logs exporting

  Why This Works

  - DO_NOT_TRACK=1 is a standard convention for opting out of telemetry
  - Setting OTEL exporters to "none" prevents OpenTelemetry from trying to load any exporter components
  - This must be done before importing Dagger to prevent the telemetry initialization during module import

  Alternative Approaches Considered

  - Installing the missing opentelemetry-exporter-otlp-proto-grpc package - rejected as it adds unnecessary dependencies
  - Forking dagger-io to remove OpenTelemetry - too complex for a simple fix
  - Using OTEL_SDK_DISABLED=true alone - insufficient, Dagger still tries to configure exporters