### PR TITLE
fix: http assets serving in Laravel apps in production

### DIFF
--- a/agent/laravel_agent/template/Dockerfile
+++ b/agent/laravel_agent/template/Dockerfile
@@ -76,6 +76,14 @@ FROM php-base AS production
 
 WORKDIR /var/www/html
 
+# Set production environment variables (can be overridden at runtime)
+ENV APP_ENV=${APP_ENV:-production}
+ENV APP_DEBUG=${APP_DEBUG:-false}
+ENV APP_DATABASE_URL=${APP_DATABASE_URL}
+ENV DB_MIGRATION_URL=${DB_MIGRATION_URL}
+ENV APP_KEY=${APP_KEY}
+
+
 # Copy application from builder
 COPY --from=app-builder --chown=www-data:www-data /var/www/html .
 
@@ -104,9 +112,6 @@ EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost/ || exit 1
 
-ENV APP_DATABASE_URL=${APP_DATABASE_URL}
-ENV DB_MIGRATION_URL=${DB_MIGRATION_URL}
-ENV APP_KEY=${APP_KEY}
 
 # Use entrypoint script to run migrations and start services
 CMD ["/usr/local/bin/entrypoint.sh"] 

--- a/agent/laravel_agent/template/app/Providers/AppServiceProvider.php
+++ b/agent/laravel_agent/template/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\URL;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if ($this->app->environment('production')) {
+            URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
## Decription

This PR aims to fix serving assets in laravel apps in production. It forces it to use `https` when the env is set to production.