### PR TITLE
feat: allow app.build previews

### DIFF
--- a/agent/trpc_agent/template/client/Caddyfile
+++ b/agent/trpc_agent/template/client/Caddyfile
@@ -8,11 +8,10 @@
 		max_size 10M
 	}
 	header {
-		X-Frame-Options "SAMEORIGIN"
 		X-XSS-Protection "1; mode=block"
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "strict-origin-when-cross-origin"
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' http://localhost:2022"
+		Content-Security-Policy "default-src 'self'; frame-ancestors https://app.build https://staging.app.build; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' http://localhost:2022"
 	}
 
 	route {


### PR DESCRIPTION
In order to be able to show live previews in the app.build ui, we will need to allow the domains to load the preview in an iframe