### PR TITLE
fix: remove statement_timeout from options

### DIFF
--- a/agent/nicegui_agent/template/app/database.py
+++ b/agent/nicegui_agent/template/app/database.py
@@ -5,7 +5,7 @@ from sqlmodel import SQLModel, create_engine, Session
 from app.models import *  # noqa: F401, F403
 
 DATABASE_URL = os.environ.get("APP_DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/postgres")
-ENGINE = create_engine(DATABASE_URL, connect_args={"connect_timeout": 15, "options": "-c statement_timeout=1000"})
+ENGINE = create_engine(DATABASE_URL, connect_args={"connect_timeout": 15})
 
 
 def create_tables():


### PR DESCRIPTION
## Description

Neon doesn't accept `statement_timeout` option, so we can't have it in the base template.