### PR TITLE
Restore pipeline builder integration for CLI

### DIFF
--- a/dabgent/dabgent_agent/src/lib.rs
+++ b/dabgent/dabgent_agent/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod event;
 pub mod llm;
+pub mod pipeline;
 pub mod processor;
 pub mod toolbox;
 pub mod sandbox_seed;
 
 pub use event::Event;
+pub use pipeline::{Pipeline, PipelineBuilder};
 pub use processor::{Aggregate, Processor};

--- a/dabgent/dabgent_agent/src/pipeline.rs
+++ b/dabgent/dabgent_agent/src/pipeline.rs
@@ -1,0 +1,213 @@
+use crate::event::Event;
+use crate::llm::LLMClient;
+use crate::processor::{
+    Aggregate, Pipeline as ProcessorPipeline, Processor, ThreadProcessor, ToolProcessor,
+    thread::{self},
+};
+use crate::toolbox::ToolDyn;
+use dabgent_mq::{
+    EventStore,
+    db::{Metadata, Query},
+};
+use dabgent_sandbox::SandboxDyn;
+use eyre::{OptionExt, Result};
+use std::marker::PhantomData;
+
+const DEFAULT_TEMPERATURE: f64 = 0.0;
+const DEFAULT_MAX_TOKENS: u64 = 4_096;
+
+pub struct PipelineBuilder<T, S>
+where
+    T: LLMClient + 'static,
+    S: EventStore,
+{
+    llm: Option<T>,
+    store: Option<S>,
+    sandbox: Option<Box<dyn SandboxDyn>>,
+    model: Option<String>,
+    preamble: Option<String>,
+    temperature: Option<f64>,
+    max_tokens: Option<u64>,
+    recipient: Option<String>,
+    tools: Vec<Box<dyn ToolDyn>>,
+}
+
+impl<T, S> PipelineBuilder<T, S>
+where
+    T: LLMClient + 'static,
+    S: EventStore,
+{
+    pub fn new() -> Self {
+        Self {
+            llm: None,
+            store: None,
+            sandbox: None,
+            model: None,
+            preamble: None,
+            temperature: None,
+            max_tokens: None,
+            recipient: None,
+            tools: Vec::new(),
+        }
+    }
+
+    pub fn llm(mut self, llm: T) -> Self {
+        self.llm = Some(llm);
+        self
+    }
+
+    pub fn store(mut self, store: S) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    pub fn sandbox(mut self, sandbox: Box<dyn SandboxDyn>) -> Self {
+        self.sandbox = Some(sandbox);
+        self
+    }
+
+    pub fn model(mut self, model: String) -> Self {
+        self.model = Some(model);
+        self
+    }
+
+    pub fn preamble(mut self, preamble: String) -> Self {
+        self.preamble = Some(preamble);
+        self
+    }
+
+    pub fn temperature(mut self, temperature: f64) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+
+    pub fn max_tokens(mut self, max_tokens: u64) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    pub fn recipient(mut self, recipient: String) -> Self {
+        self.recipient = Some(recipient);
+        self
+    }
+
+    pub fn tool(mut self, tool: Box<dyn ToolDyn>) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    pub fn tools(mut self, tools: Vec<Box<dyn ToolDyn>>) -> Self {
+        self.tools.extend(tools);
+        self
+    }
+
+    pub fn build(self) -> Result<Pipeline<T, S>> {
+        let llm = self.llm.ok_or_eyre("LLM Client not provided")?;
+        let store = self.store.ok_or_eyre("Event Store not provided")?;
+        let sandbox = self.sandbox.ok_or_eyre("Sandbox not provided")?;
+        let model = self.model.ok_or_eyre("Model not provided")?;
+        let temperature = self.temperature.unwrap_or(DEFAULT_TEMPERATURE);
+        let max_tokens = self.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
+        let preamble = self.preamble;
+        let recipient = self.recipient;
+
+        let tool_definitions = if self.tools.is_empty() {
+            Vec::new()
+        } else {
+            self.tools.iter().map(|tool| tool.definition()).collect()
+        };
+
+        let thread_processor = ThreadProcessor::new(llm, store.clone());
+        let tool_processor =
+            ToolProcessor::new(sandbox, store.clone(), self.tools, recipient.clone());
+        let processors = vec![thread_processor.boxed(), tool_processor.boxed()];
+        let pipeline = ProcessorPipeline::new(store.clone(), processors);
+
+        Ok(Pipeline {
+            store,
+            pipeline,
+            config: ThreadConfig {
+                model,
+                preamble,
+                temperature,
+                max_tokens,
+                tools: tool_definitions,
+                recipient,
+            },
+            _marker: PhantomData,
+        })
+    }
+}
+
+struct ThreadConfig {
+    model: String,
+    preamble: Option<String>,
+    temperature: f64,
+    max_tokens: u64,
+    tools: Vec<rig::completion::ToolDefinition>,
+    recipient: Option<String>,
+}
+
+pub struct Pipeline<T, S>
+where
+    T: LLMClient + 'static,
+    S: EventStore,
+{
+    store: S,
+    pipeline: ProcessorPipeline<S, Event>,
+    config: ThreadConfig,
+    _marker: PhantomData<T>,
+}
+
+impl<T, S> Pipeline<T, S>
+where
+    T: LLMClient + 'static,
+    S: EventStore,
+{
+    pub async fn run(self, stream_id: String, aggregate_id: String) -> Result<()> {
+        self.initialize_thread(&stream_id, &aggregate_id).await?;
+        let pipeline = self.pipeline;
+        pipeline.run(stream_id).await
+    }
+
+    async fn initialize_thread(&self, stream_id: &str, aggregate_id: &str) -> Result<()> {
+        let query = Query::stream(stream_id).aggregate(aggregate_id);
+        let events = self.store.load_events::<Event>(&query, None).await?;
+        if events
+            .iter()
+            .any(|event| matches!(event, Event::LLMConfig { .. }))
+        {
+            return Ok(());
+        }
+
+        let mut thread = thread::Thread::default();
+        let events = thread.process(thread::Command::Setup {
+            model: self.config.model.clone(),
+            temperature: self.config.temperature,
+            max_tokens: self.config.max_tokens,
+            preamble: self.config.preamble.clone(),
+            tools: if self.config.tools.is_empty() {
+                None
+            } else {
+                Some(self.config.tools.clone())
+            },
+            recipient: self.config.recipient.clone(),
+        })?;
+        persist_events(&self.store, stream_id, aggregate_id, events).await
+    }
+}
+
+async fn persist_events<S: EventStore>(
+    store: &S,
+    stream_id: &str,
+    aggregate_id: &str,
+    events: Vec<Event>,
+) -> Result<()> {
+    let metadata = Metadata::default();
+    for event in events.iter() {
+        store
+            .push_event(stream_id, aggregate_id, event, &metadata)
+            .await?;
+    }
+    Ok(())
+}

--- a/dabgent/dabgent_cli/src/agent.rs
+++ b/dabgent/dabgent_cli/src/agent.rs
@@ -14,6 +14,9 @@ Program will be run using uv run main.py command.
 ";
 
 const MODEL: &str = "claude-sonnet-4-20250514";
+const RECIPIENT: &str = "sandbox";
+const DEFAULT_TEMPERATURE: f64 = 0.0;
+const DEFAULT_MAX_TOKENS: u64 = 4_096;
 
 pub async fn run_pipeline(store: impl EventStore, stream_id: String) {
     const AGGREGATE_ID: &str = "thread";
@@ -23,13 +26,15 @@ pub async fn run_pipeline(store: impl EventStore, stream_id: String) {
         let llm = rig::providers::anthropic::Client::from_env();
         let sandbox = sandbox(&client).await?;
         let tools = toolset(Validator);
-
         let pipeline = PipelineBuilder::new()
             .llm(llm)
             .store(store)
             .sandbox(sandbox.boxed())
             .model(MODEL.to_owned())
+            .temperature(DEFAULT_TEMPERATURE)
+            .max_tokens(DEFAULT_MAX_TOKENS)
             .preamble(SYSTEM_PROMPT.to_owned())
+            .recipient(RECIPIENT.to_owned())
             .tools(tools)
             .build()?;
 

--- a/dabgent/dabgent_cli/src/agent.rs
+++ b/dabgent/dabgent_cli/src/agent.rs
@@ -52,7 +52,7 @@ async fn sandbox(client: &dagger_sdk::DaggerConn) -> Result<DaggerSandbox> {
         .build()?;
     let ctr = client
         .container()
-        .build_opts(client.host().directory("./dabgent_agent/examples"), opts);
+        .build_opts(client.host().directory("./examples"), opts);
     ctr.sync().await?;
     let sandbox = DaggerSandbox::from_container(ctr, client.clone());
     Ok(sandbox)

--- a/dabgent/dabgent_cli/src/app.rs
+++ b/dabgent/dabgent_cli/src/app.rs
@@ -142,6 +142,9 @@ impl<S: EventStore> App<S> {
             model: "claude-sonnet-4-20250514".to_string(),
             temperature: 0.7,
             max_tokens: 4096,
+            preamble: Some("You are a helpful AI assistant.".to_string()),
+            tools: None,
+            recipient: None,
         };
 
         let events = self.thread.process(setup_command)?;
@@ -152,8 +155,8 @@ impl<S: EventStore> App<S> {
                 .push_event(
                     &self.query.stream_id,
                     &self.query.aggregate_id.clone().unwrap_or_default(),
-                    event.clone(),
-                    metadata.clone(),
+                    &event,
+                    &metadata,
                 )
                 .await?;
         }

--- a/dabgent/dabgent_cli/src/events.rs
+++ b/dabgent/dabgent_cli/src/events.rs
@@ -1,6 +1,6 @@
 use color_eyre::eyre::OptionExt;
 use crossterm::event::Event as CrosstermEvent;
-use dabgent_agent::thread::{self};
+use dabgent_agent::event::Event as AgentEvent;
 use dabgent_mq::db::EventStream;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -20,7 +20,7 @@ pub enum AppEvent {
 pub enum Event {
     Tick,
     Crossterm(CrosstermEvent),
-    Thread(thread::Event),
+    Thread(AgentEvent),
     App(AppEvent),
 }
 
@@ -30,7 +30,7 @@ pub struct EventHandler {
 }
 
 impl EventHandler {
-    pub fn new(events_stream: EventStream<thread::Event>) -> Self {
+    pub fn new(events_stream: EventStream<AgentEvent>) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
         let actor = EventTask::new(sender.clone());
         tokio::spawn(async { actor.run().await });
@@ -53,11 +53,11 @@ impl EventHandler {
 
 pub struct StoreTask {
     sender: mpsc::UnboundedSender<Event>,
-    receiver: EventStream<thread::Event>,
+    receiver: EventStream<AgentEvent>,
 }
 
 impl StoreTask {
-    pub fn new(sender: mpsc::UnboundedSender<Event>, receiver: EventStream<thread::Event>) -> Self {
+    pub fn new(sender: mpsc::UnboundedSender<Event>, receiver: EventStream<AgentEvent>) -> Self {
         Self { sender, receiver }
     }
 

--- a/dabgent/dabgent_cli/src/widgets.rs
+++ b/dabgent/dabgent_cli/src/widgets.rs
@@ -53,6 +53,10 @@ pub fn event_as_text(event: &AgentEvent) -> Text<'_> {
         AgentEvent::AgentMessage { response, .. } => render_agent_message(response),
         AgentEvent::UserMessage(content) => render_user_message(content),
         AgentEvent::ArtifactsCollected(artifacts) => render_artifacts_collected(artifacts),
+        AgentEvent::TaskCompleted { .. } => Text::raw("Task completed"),
+        AgentEvent::SeedSandboxFromTemplate { .. } => Text::raw("Sandbox seeded from template"),
+        AgentEvent::SandboxSeeded { .. } => Text::raw("Sandbox seeded"),
+        AgentEvent::PipelineShutdown => Text::raw("Pipeline shutdown"),
     }
 }
 

--- a/dabgent/dabgent_cli/src/widgets.rs
+++ b/dabgent/dabgent_cli/src/widgets.rs
@@ -1,5 +1,5 @@
+use dabgent_agent::event::Event as AgentEvent;
 use dabgent_agent::llm::CompletionResponse;
-use dabgent_agent::thread::{Event, ToolResponse};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -12,11 +12,11 @@ use rig::completion::message::{
 };
 
 pub struct EventList<'a> {
-    events: &'a [Event],
+    events: &'a [AgentEvent],
 }
 
 impl<'a> EventList<'a> {
-    pub fn new(events: &'a [Event]) -> Self {
+    pub fn new(events: &'a [AgentEvent]) -> Self {
         Self { events }
     }
 }
@@ -40,17 +40,20 @@ impl Widget for EventList<'_> {
     }
 }
 
-pub fn event_as_text(event: &Event) -> Text<'_> {
+pub fn event_as_text(event: &AgentEvent) -> Text<'_> {
     match event {
-        Event::Prompted(prompt) => render_prompted(prompt),
-        Event::LlmCompleted(completion) => render_llm_completed(completion),
-        Event::ToolCompleted(result) => render_tool_completed(result),
-        Event::ArtifactsCollected(artifacts) => render_artifacts_collected(artifacts),
+        AgentEvent::LLMConfig {
+            model,
+            temperature,
+            max_tokens,
+            preamble,
+            tools,
+            recipient,
+        } => render_llm_config(model, *temperature, *max_tokens, preamble, tools, recipient),
+        AgentEvent::AgentMessage { response, .. } => render_agent_message(response),
+        AgentEvent::UserMessage(content) => render_user_message(content),
+        AgentEvent::ArtifactsCollected(artifacts) => render_artifacts_collected(artifacts),
     }
-}
-
-pub fn render_prompted(prompt: &str) -> Text<'_> {
-    Text::from_iter(prompt.lines().map(|line| Line::from(line.to_owned())))
 }
 
 pub fn render_artifacts_collected(
@@ -59,7 +62,51 @@ pub fn render_artifacts_collected(
     Text::from(format!("Collected {} artifacts", artifacts.len()))
 }
 
-pub fn render_llm_completed(completion: &CompletionResponse) -> Text<'_> {
+pub fn render_llm_config<'a>(
+    model: &'a str,
+    temperature: f64,
+    max_tokens: u64,
+    preamble: &'a Option<String>,
+    tools: &'a Option<Vec<rig::completion::ToolDefinition>>,
+    recipient: &'a Option<String>,
+) -> Text<'a> {
+    let mut lines = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Configured model", Style::new().bold()),
+        Span::raw(format!(": {model}")),
+    ]));
+    lines.push(Line::from(format!(
+        "temperature: {temperature}, max_tokens: {max_tokens}"
+    )));
+    if let Some(preamble) = preamble {
+        lines.push(Line::from(vec![
+            Span::styled("preamble", Style::new().italic()),
+            Span::raw(": "),
+            Span::raw(preamble.clone()),
+        ]));
+    }
+    if let Some(tools) = tools {
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect::<Vec<_>>();
+        lines.push(Line::from(vec![
+            Span::styled("tools", Style::new().italic()),
+            Span::raw(": "),
+            Span::raw(names.join(", ")),
+        ]));
+    }
+    if let Some(recipient) = recipient {
+        lines.push(Line::from(vec![
+            Span::styled("recipient", Style::new().italic()),
+            Span::raw(": "),
+            Span::raw(recipient.clone()),
+        ]));
+    }
+    Text::from(lines)
+}
+
+pub fn render_agent_message(completion: &CompletionResponse) -> Text<'_> {
     let mut lines = Vec::new();
     for item in completion.choice.iter() {
         match item {
@@ -82,9 +129,9 @@ pub fn render_llm_completed(completion: &CompletionResponse) -> Text<'_> {
     Text::from(lines)
 }
 
-pub fn render_tool_completed(response: &ToolResponse) -> Text<'_> {
+pub fn render_user_message(response: &rig::OneOrMany<UserContent>) -> Text<'_> {
     let mut lines = Vec::new();
-    for item in response.content.iter() {
+    for item in response.iter() {
         match item {
             UserContent::Text(text) => {
                 for line in text.text.lines() {
@@ -94,7 +141,10 @@ pub fn render_tool_completed(response: &ToolResponse) -> Text<'_> {
             UserContent::ToolResult(tool_result) => {
                 lines.append(&mut tool_result_lines(tool_result));
             }
-            _ => continue,
+            UserContent::Image(_) => lines.push(Line::from("[image]")),
+            UserContent::Audio(_) => lines.push(Line::from("[audio]")),
+            UserContent::Video(_) => lines.push(Line::from("[video]")),
+            UserContent::Document(_) => lines.push(Line::from("[document]")),
         }
     }
     Text::from(lines)


### PR DESCRIPTION
## Summary
- add a reusable pipeline builder that seeds thread configuration before starting the processor pipeline
- expose the pipeline builder from the agent crate and switch the CLI to construct its pipeline through it
- keep CLI defaults (model, temperature, recipient, tools) wired through the builder while reusing the sandbox helper

## Testing
- cargo check -p dabgent_cli
- cargo run -p dabgent_cli -- --help

------
https://chatgpt.com/codex/tasks/task_e_68d29e101840832594aaf33b04dbbe1c

<img width="818" height="358" alt="image" src="https://github.com/user-attachments/assets/e9b04e39-7560-4085-95fd-6653817402af" />
