### PR TITLE
Add planner user feedback event

### DIFF
--- a/dabgent/dabgent_agent/src/event.rs
+++ b/dabgent/dabgent_agent/src/event.rs
@@ -1,5 +1,6 @@
 use crate::llm::CompletionResponse;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,6 +59,10 @@ pub enum Event {
     PlanUpdated {
         tasks: Vec<String>,
     },
+    UserInputRequested {
+        prompt: String,
+        context: Option<Value>,
+    },
 }
 
 impl dabgent_mq::Event for Event {
@@ -76,6 +81,7 @@ impl dabgent_mq::Event for Event {
             Event::PipelineShutdown => "pipeline_shutdown",
             Event::PlanCreated { .. } => "plan_created",
             Event::PlanUpdated { .. } => "plan_updated",
+            Event::UserInputRequested { .. } => "user_input_requested",
         }
     }
 }

--- a/dabgent/dabgent_cli/src/app.rs
+++ b/dabgent/dabgent_cli/src/app.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use dabgent_agent::Aggregate;
 use dabgent_agent::event::Event as AgentEvent;
 use dabgent_agent::processor::thread::{self};
-use dabgent_mq::db::{EventStore, Metadata, Query};
+use dabgent_mq::db::{Event as StoreEvent, EventStore, Metadata, Query};
 use rig::OneOrMany;
 use rig::message::{Text, UserContent};
 
@@ -11,21 +11,19 @@ pub struct App<S: EventStore> {
     store: S,
     query: Query,
     pub thread: thread::Thread,
-    pub history: Vec<AgentEvent>,
+    pub history: Vec<StoreEvent<AgentEvent>>,
     pub input_buffer: String,
     pub running: bool,
     pub events: EventHandler,
+    pub pending_prompt: Option<String>,
+    pub pending_prompt_target: Option<String>,
 }
 
 impl<S: EventStore> App<S> {
     pub fn new(store: S, stream_id: String) -> color_eyre::Result<Self> {
-        let query = Query {
-            stream_id: stream_id.clone(),
-            event_type: None,
-            aggregate_id: Some("thread".to_owned()),
-        };
+        let query = Query::stream(stream_id.clone()).aggregate("thread");
 
-        let event_stream = store.subscribe::<AgentEvent>(&query)?;
+        let event_stream = store.subscribe::<AgentEvent>(&Query::stream(stream_id.clone()))?;
         let events = EventHandler::new(event_stream);
         let thread = thread::Thread::new();
 
@@ -37,6 +35,8 @@ impl<S: EventStore> App<S> {
             input_buffer: String::new(),
             running: true,
             events,
+            pending_prompt: None,
+            pending_prompt_target: None,
         })
     }
 
@@ -52,8 +52,24 @@ impl<S: EventStore> App<S> {
                     _ => {}
                 },
                 UiEvent::Thread(event) => {
+                    let aggregate_id = event.aggregate_id.clone();
+                    if let dabgent_agent::event::Event::UserInputRequested { prompt, .. } =
+                        &event.data
+                    {
+                        self.pending_prompt = Some(prompt.clone());
+                        self.pending_prompt_target = Some(aggregate_id.clone());
+                    }
+
                     self.history.push(event);
-                    self.fold_thread().await?;
+                    if self
+                        .query
+                        .aggregate_id
+                        .as_ref()
+                        .map(|agg| aggregate_id == *agg)
+                        .unwrap_or(false)
+                    {
+                        self.fold_thread().await?;
+                    }
                 }
                 UiEvent::App(app_event) => match app_event {
                     AppEvent::Confirm => self.confirm().await?,
@@ -88,22 +104,40 @@ impl<S: EventStore> App<S> {
         Ok(())
     }
 
-    async fn send_message(&mut self, content: String) -> color_eyre::Result<()> {
+    async fn send_message_to(
+        &mut self,
+        aggregate_id: &str,
+        content: String,
+    ) -> color_eyre::Result<()> {
         let text = UserContent::Text(Text { text: content });
         let message = OneOrMany::one(text);
-        let command = thread::Command::User(message);
-        let events = self.thread.process(command)?;
         let metadata = Metadata::default();
-        for event in events {
-            self.store
-                .push_event(
-                    &self.query.stream_id,
-                    self.query.aggregate_id.as_ref().unwrap(),
-                    &event,
-                    &metadata,
-                )
-                .await?;
+
+        if self
+            .query
+            .aggregate_id
+            .as_ref()
+            .map(|current| current == aggregate_id)
+            .unwrap_or(false)
+        {
+            let events = self.thread.process(thread::Command::User(message))?;
+            for event in events {
+                self.store
+                    .push_event(&self.query.stream_id, aggregate_id, &event, &metadata)
+                    .await?;
+            }
+        } else {
+            let query = Query::stream(&self.query.stream_id).aggregate(aggregate_id);
+            let events = self.store.load_events::<AgentEvent>(&query, None).await?;
+            let mut thread = thread::Thread::fold(&events);
+            let events = thread.process(thread::Command::User(message))?;
+            for event in events {
+                self.store
+                    .push_event(&self.query.stream_id, aggregate_id, &event, &metadata)
+                    .await?;
+            }
         }
+
         Ok(())
     }
 
@@ -121,8 +155,20 @@ impl<S: EventStore> App<S> {
 
     pub async fn confirm(&mut self) -> color_eyre::Result<()> {
         if !self.input_buffer.is_empty() {
-            self.send_message(self.input_buffer.clone()).await?;
+            let aggregate_id = self
+                .pending_prompt_target
+                .clone()
+                .or_else(|| self.query.aggregate_id.clone())
+                .unwrap_or_else(|| "thread".to_string());
+
+            self.send_message_to(&aggregate_id, self.input_buffer.clone())
+                .await?;
             self.input_buffer.clear();
+
+            if self.pending_prompt_target.is_some() {
+                self.pending_prompt = None;
+                self.pending_prompt_target = None;
+            }
         }
         Ok(())
     }

--- a/dabgent/dabgent_cli/src/ui.rs
+++ b/dabgent/dabgent_cli/src/ui.rs
@@ -35,7 +35,7 @@ impl<S: EventStore> App<S> {
         let items: Vec<ListItem> = self
             .history
             .iter()
-            .map(|event| ListItem::new(event_as_text(event)))
+            .map(|event| ListItem::new(event_as_text(&event.aggregate_id, &event.data)))
             .collect();
 
         let messages_list = List::new(items)
@@ -54,13 +54,21 @@ impl<S: EventStore> App<S> {
     }
 
     fn draw_input(&self, area: Rect, buf: &mut Buffer) {
+        let mut title = if let Some(prompt) = &self.pending_prompt {
+            format!("Input (Enter to send) - {prompt}")
+        } else {
+            "Input (Enter to send)".to_string()
+        };
+
+        const MAX_TITLE_LEN: usize = 80;
+        if title.len() > MAX_TITLE_LEN {
+            title.truncate(MAX_TITLE_LEN);
+            title.push('…');
+        }
+
         let input = Paragraph::new(self.input_buffer.as_str())
             .style(Style::default())
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title("Input (Enter to send)"),
-            );
+            .block(Block::default().borders(Borders::ALL).title(title));
 
         input.render(area, buf);
     }


### PR DESCRIPTION
## Summary
- add a new `UserInputRequested` event variant that carries a prompt/context for planner feedback requests
- emit feedback requests from the planning toolbox and update the planning example to surface and answer them
- extend the CLI to listen for planner requests, show the prompt in the UI, and route user responses to the correct aggregate

## Testing
- `cargo test -p dabgent_agent` *(fails: requires ANTHROPIC_API_KEY & GEMINI_API_KEY)*
- `cargo test -p dabgent_cli`


------
https://chatgpt.com/codex/tasks/task_e_68d558dbfb648325bb1ca7484c305da5