### PR TITLE
Use manifest directory when locating example Dockerfiles

### DIFF
--- a/dabgent/dabgent_agent/examples/basic.rs
+++ b/dabgent/dabgent_agent/examples/basic.rs
@@ -1,6 +1,8 @@
 use dabgent_agent::processor::agent::{Agent, AgentState, Command, Event, Request, Runtime};
 use dabgent_agent::processor::llm::{LLMConfig, LLMHandler};
-use dabgent_agent::processor::tools::{TemplateConfig, ToolHandler};
+use dabgent_agent::processor::tools::{
+    get_dockerfile_dir_from_src_ws, TemplateConfig, ToolHandler,
+};
 use dabgent_agent::processor::utils::LogHandler;
 use dabgent_agent::toolbox::{self, basic::toolset};
 use dabgent_mq::Event as MQEvent;
@@ -47,7 +49,7 @@ pub async fn run_worker() -> Result<()> {
     let tool_handler = ToolHandler::new(
         tools,
         SandboxHandle::new(Default::default()),
-        TemplateConfig::default_dir("./examples"),
+        TemplateConfig::default_dir(get_dockerfile_dir_from_src_ws()),
     );
 
     let runtime = Runtime::<Basic, _>::new(store, ())

--- a/dabgent/dabgent_agent/examples/planner_worker.rs
+++ b/dabgent/dabgent_agent/examples/planner_worker.rs
@@ -3,7 +3,9 @@ use dabgent_agent::processor::agent::{
 };
 use dabgent_agent::processor::link::{Link, link_runtimes};
 use dabgent_agent::processor::llm::{LLMConfig, LLMHandler};
-use dabgent_agent::processor::tools::{TemplateConfig, ToolHandler};
+use dabgent_agent::processor::tools::{
+    get_dockerfile_dir_from_src_ws, TemplateConfig, ToolHandler,
+};
 use dabgent_agent::processor::utils::LogHandler;
 use dabgent_agent::toolbox::{self, basic::toolset};
 use dabgent_mq::db::sqlite::SqliteStore;
@@ -70,7 +72,7 @@ pub async fn run_planner_worker() -> Result<()> {
     let worker_tool_handler = ToolHandler::new(
         worker_tools,
         SandboxHandle::new(Default::default()),
-        TemplateConfig::default_dir("./examples"),
+        TemplateConfig::default_dir(get_dockerfile_dir_from_src_ws()),
     );
     let mut worker_runtime = Runtime::<Worker, _>::new(store.clone(), ())
         .with_handler(worker_llm)

--- a/dabgent/dabgent_agent/src/processor/tools.rs
+++ b/dabgent/dabgent_agent/src/processor/tools.rs
@@ -26,6 +26,15 @@ impl TemplateConfig {
     }
 }
 
+/// Dockerfile dir from the source workspace
+pub fn get_dockerfile_dir_from_src_ws() -> String {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .to_str()
+        .expect("project dir is a non-Unicode string")
+        .to_owned()
+}
+
 pub struct ToolHandler {
     tools: Vec<Box<dyn ToolDyn>>,
     dagger: SandboxHandle,


### PR DESCRIPTION
## Summary
- add a helper that resolves the examples Dockerfile relative to `CARGO_MANIFEST_DIR`
- use the helper in the basic and planner worker examples so template loading is workspace-aware

## Testing
- `cargo check --manifest-path dabgent/dabgent_agent/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68deb4accaa48325a2e3f515398ef61e