### PR TITLE
Adjust Rust CI checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,10 +35,6 @@ jobs:
             dabgent/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run cargo check
-        working-directory: ./dabgent
-        run: cargo check --workspace
-
       - name: Run cargo check all targets
         working-directory: ./dabgent
         run: cargo check --all-targets --workspace
@@ -72,10 +68,8 @@ jobs:
 
       - name: Run unit tests
         working-directory: ./dabgent
-        run: cargo test --lib --workspace
-        continue-on-error: true
+        run: cargo test --lib --bins --workspace
 
       - name: Run integration tests
         working-directory: ./dabgent
         run: cargo test --workspace --test '*'
-        continue-on-error: true


### PR DESCRIPTION
## Summary
- remove the redundant `cargo check --workspace` step in the Rust workflow
- update the unit test job to run both library and binary tests without continuing on error
- run integration tests without allowing failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7ad55b1f8832594224f40e8bcdcb9