### PR TITLE
fixes for MCP build/release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,21 @@
-name: Release
+name: Release MCP server
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., v0.0.1)'
+        description: "Version tag (e.g., v0.0.1)"
         required: true
         type: string
       commit_sha:
-        description: 'Commit SHA to release'
+        description: "Commit SHA to release"
         required: true
         type: string
       release_notes:
-        description: 'Release notes'
+        description: "Release notes"
         required: false
         type: string
-        default: ''
+        default: ""
 
 jobs:
   validate-and-tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   validate-and-tag:
     name: Validate and Create Tag

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,3 +134,36 @@ jobs:
           name: dabgent-mcp-${{ matrix.platform }}
           path: dabgent/target/release/dabgent_mcp
           retention-days: 30
+
+  smoke-test-mcp:
+    name: Smoke Test MCP Binary (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    needs: build-dabgent-mcp
+    strategy:
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-latest
+          - platform: macos-arm64
+            runner: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dabgent-mcp-${{ matrix.platform }}
+          path: ./binary
+
+      - name: Make binary executable
+        run: chmod +x ./binary/dabgent_mcp
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Run smoke test
+        run: python3 scripts/smoke_test_mcp.py ./binary/dabgent_mcp

--- a/scripts/smoke_test_mcp.py
+++ b/scripts/smoke_test_mcp.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Smoke test for dabgent_mcp binary.
+Verifies the MCP server starts, responds to protocol messages, and lists tools.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def send_request(process: subprocess.Popen, request: dict) -> dict:
+    """send JSON-RPC request and read response"""
+    request_line = json.dumps(request) + "\n"
+    process.stdin.write(request_line.encode())
+    process.stdin.flush()
+
+    response_line = process.stdout.readline().decode().strip()
+    if not response_line:
+        raise RuntimeError("no response from MCP server")
+
+    return json.loads(response_line)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <path-to-dabgent_mcp-binary>")
+        sys.exit(1)
+
+    binary_path = Path(sys.argv[1])
+    if not binary_path.exists():
+        print(f"Error: Binary not found at {binary_path}")
+        sys.exit(1)
+
+    print(f"Starting MCP server: {binary_path}")
+
+    # start the MCP server
+    process = subprocess.Popen(
+        [str(binary_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        # 1. initialize request
+        print("\n1. Sending initialize request...")
+        init_response = send_request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "smoke-test", "version": "1.0.0"},
+                },
+            },
+        )
+
+        if "result" not in init_response:
+            print(f"❌ Initialize failed: {init_response}")
+            sys.exit(1)
+
+        server_info = init_response["result"]
+        print(f"✓ Server initialized: {server_info.get('serverInfo', {})}")
+
+        # send initialized notification (no response expected)
+        print("\n2. Sending initialized notification...")
+        notification = json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n"
+        process.stdin.write(notification.encode())
+        process.stdin.flush()
+        print("✓ Initialized notification sent")
+
+        # 3. list tools request
+        print("\n3. Sending tools/list request...")
+        tools_response = send_request(
+            process,
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+
+        if "result" not in tools_response:
+            print(f"❌ tools/list failed: {tools_response}")
+            sys.exit(1)
+
+        tools = tools_response["result"].get("tools", [])
+        tool_names = [tool["name"] for tool in tools]
+
+        print(f"\n✓ Found {len(tools)} tools:")
+        for name in sorted(tool_names):
+            print(f"  - {name}")
+
+        # 4. verify expected tools (IOProvider is always available)
+        expected_tools = ["scaffold_data_app", "validate_data_app"]
+        missing_tools = [tool for tool in expected_tools if tool not in tool_names]
+
+        if missing_tools:
+            print(f"\n❌ Missing expected tools: {missing_tools}")
+            sys.exit(1)
+
+        print(f"\n✓ All expected tools present: {expected_tools}")
+
+        print("\n✅ Smoke test passed!")
+
+    except Exception as e:
+        print(f"\n❌ Smoke test failed: {e}")
+        stderr = process.stderr.read().decode()
+        if stderr:
+            print(f"\nServer stderr:\n{stderr}")
+        sys.exit(1)
+
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR enables to create tag with the binaries in semi-manual mode. To create a new release, go to Github Actions, choose "Release MCP Server" and choose tag.

Mac binaries may need to use the MCP:
```
xattr -d com.apple.quarantine  ./dabgent_mcp-macos-arm64
```