### PR TITLE
Fix EvalAgent for root execution on Databricks clusters

### DIFF
--- a/klaudbiusz/cli/evaluation/evaluate_app.py
+++ b/klaudbiusz/cli/evaluation/evaluate_app.py
@@ -53,6 +53,15 @@ except ImportError:
     anthropic = None
 
 
+def _is_running_as_root() -> bool:
+    """Check if running as root user.
+
+    Claude SDK's --dangerously-skip-permissions flag doesn't work as root,
+    so we need to fall back to shell scripts when running as root (e.g., on Databricks).
+    """
+    return os.geteuid() == 0 if hasattr(os, 'geteuid') else False
+
+
 def _is_databricks_auth_available() -> bool:
     """Check if Databricks authentication is available (either env vars or SDK auto-auth).
 


### PR DESCRIPTION
## Summary

- Fix `EvalAgent` to work on Databricks clusters which run as root
- Claude SDK's `--dangerously-skip-permissions` flag doesn't work when running as root (security measure)

## Problem

When running evaluations on Databricks clusters:
```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

This caused all evaluations to score 0.

## Solution

Added shell script fallback in `EvalAgent`:
1. Detect if running as root (`os.geteuid() == 0`)
2. If root, use direct `subprocess.run()` with shell commands
3. Otherwise, use Claude SDK agent as before

## Test plan

- [ ] Re-run the apps-mcp-evals pipeline on Databricks
- [ ] Verify evaluations no longer fail with permission errors
- [ ] Verify metrics are non-zero for working apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)