### PR TITLE
Add typegen to build/typecheck for AppKit apps

### DIFF
--- a/klaudbiusz/cli/evaluation/eval_agent.py
+++ b/klaudbiusz/cli/evaluation/eval_agent.py
@@ -77,6 +77,11 @@ fi
 """,
     "build": """
 cd {app_dir}
+# Generate TypeScript types from schema before building (AppKit apps)
+if [ -f "scripts/generate-types.ts" ]; then
+    npm run typegen 2>/dev/null || true
+fi
+# Run build
 if [ -f "client/package.json" ]; then
     (cd client && npm run build)
 elif [ -f "package.json" ]; then
@@ -85,6 +90,11 @@ fi
 """,
     "typecheck": """
 cd {app_dir}
+# Generate TypeScript types from schema before checking (AppKit apps)
+if [ -f "scripts/generate-types.ts" ]; then
+    npm run typegen 2>/dev/null || true
+fi
+# Run type checking
 for dir in . server client; do
     if [ -f "$dir/tsconfig.json" ]; then
         (cd "$dir" && npx tsc --noEmit --skipLibCheck)


### PR DESCRIPTION
## Summary

- Add `npm run typegen` to build and typecheck shell commands for AppKit apps
- This regenerates TypeScript types from `schema.ts` before building

## Problem

Generated AppKit apps have TypeScript errors because `appKitTypes.d.ts` has stale default types (`mocked_sales`, `hello_world`) instead of the actual query names defined in `schema.ts`.

Error example:
```
Argument of type '"customer_cohort_ltv"' is not assignable to parameter of type '"mocked_sales" | "hello_world"'
```

## Solution

Run `npm run typegen` before build/typecheck steps to regenerate types from schema. Only runs for apps that have the typegen script.

## Test plan

- [ ] Re-run evals pipeline
- [ ] Verify Build Success metric improves
- [ ] Verify Type Safety metric maintains/improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)