### PR TITLE
Fix esbuild platform mismatch on Databricks clusters

### DIFF
--- a/klaudbiusz/cli/evaluation/eval_agent.py
+++ b/klaudbiusz/cli/evaluation/eval_agent.py
@@ -74,12 +74,16 @@ else
         fi
     done
 fi
+# Rebuild native modules for current platform (fixes esbuild on Databricks)
+npm rebuild esbuild 2>/dev/null || true
 """,
     "build": """
 cd {app_dir}
 # Generate TypeScript types from schema before building (AppKit apps)
 if [ -f "scripts/generate-types.ts" ]; then
-    npm run typegen 2>/dev/null || true
+    # Rebuild esbuild for current platform (fixes architecture mismatch on Databricks)
+    npm rebuild esbuild 2>/dev/null || true
+    npm run typegen 2>&1 || echo "Warning: typegen failed, continuing with build..."
 fi
 # Run build
 if [ -f "client/package.json" ]; then
@@ -92,7 +96,9 @@ fi
 cd {app_dir}
 # Generate TypeScript types from schema before checking (AppKit apps)
 if [ -f "scripts/generate-types.ts" ]; then
-    npm run typegen 2>/dev/null || true
+    # Rebuild esbuild for current platform (fixes architecture mismatch on Databricks)
+    npm rebuild esbuild 2>/dev/null || true
+    npm run typegen 2>&1 || echo "Warning: typegen failed, continuing with typecheck..."
 fi
 # Run type checking
 for dir in . server client; do


### PR DESCRIPTION
## Summary
- Add `npm rebuild esbuild` to install/build/typecheck steps in eval_agent.py
- Fixes architecture mismatch when running AppKit apps on Databricks Linux clusters
- This addresses the typegen failures seen in CI/CD evaluations

## Problem
When apps are generated on macOS and then evaluated on Databricks (Linux), the esbuild binary has wrong platform architecture. This causes `npm run typegen` (which uses tsx/esbuild) to fail.

## Solution
Rebuild esbuild for the current platform during install and before typegen commands.

## Test plan
- [x] Type check passes (`uv run pyright cli/evaluation/eval_agent.py`)
- [ ] Verify in Databricks job run that typegen no longer fails due to esbuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)