### PR TITLE
Make Rust tests conditional on API key availability

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,8 @@ jobs:
     name: Rust Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only run when API keys are available (skipped for forks/external PRs)
+    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -75,6 +77,8 @@ jobs:
     name: Rust Tests (Dagger)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Only run when API keys are available (skipped for forks/external PRs)
+    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -144,7 +148,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     needs: [rust-checks, rust-tests, rust-tests-dagger, check-release-condition]
-    if: needs.check-release-condition.outputs.should_build == 'true'
+    # Build if: release condition met, checks passed, and tests passed or were skipped (no API keys)
+    if: |
+      always() &&
+      needs.check-release-condition.outputs.should_build == 'true' &&
+      needs.rust-checks.result == 'success' &&
+      (needs.rust-tests.result == 'success' || needs.rust-tests.result == 'skipped') &&
+      (needs.rust-tests-dagger.result == 'success' || needs.rust-tests-dagger.result == 'skipped')
     strategy:
       matrix:
         include:

--- a/klaudbiusz/cli/evaluation/eval_agent.py
+++ b/klaudbiusz/cli/evaluation/eval_agent.py
@@ -74,12 +74,16 @@ else
         fi
     done
 fi
+# Rebuild native modules for current platform (fixes esbuild on Databricks)
+npm rebuild esbuild 2>/dev/null || true
 """,
     "build": """
 cd {app_dir}
 # Generate TypeScript types from schema before building (AppKit apps)
 if [ -f "scripts/generate-types.ts" ]; then
-    npm run typegen 2>/dev/null || true
+    # Rebuild esbuild for current platform (fixes architecture mismatch on Databricks)
+    npm rebuild esbuild 2>/dev/null || true
+    npm run typegen 2>&1 || echo "Warning: typegen failed, continuing with build..."
 fi
 # Run build
 if [ -f "client/package.json" ]; then
@@ -92,7 +96,9 @@ fi
 cd {app_dir}
 # Generate TypeScript types from schema before checking (AppKit apps)
 if [ -f "scripts/generate-types.ts" ]; then
-    npm run typegen 2>/dev/null || true
+    # Rebuild esbuild for current platform (fixes architecture mismatch on Databricks)
+    npm rebuild esbuild 2>/dev/null || true
+    npm run typegen 2>&1 || echo "Warning: typegen failed, continuing with typecheck..."
 fi
 # Run type checking
 for dir in . server client; do


### PR DESCRIPTION
## Summary
- Skip Rust tests when `ANTHROPIC_API_KEY` is not available (e.g., forks, external PRs)
- Build job now proceeds if tests pass OR are skipped (for API key unavailability)

## Test plan
- [ ] CI runs with tests skipped when API key is not available
- [ ] CI runs with tests executed when API key is available
- [ ] Build job proceeds after skipped tests

🤖 Generated with [Claude Code](https://claude.ai/code)