### PR TITLE
OpenCode cost tracking + OpenRouter support

### DIFF
--- a/klaudbiusz/Dockerfile
+++ b/klaudbiusz/Dockerfile
@@ -67,8 +67,10 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
     cd cli/generation_opencode && bun install
 
 # create non-root user (claude agent sdk requires non-root for security)
+# pre-create .local directories for opencode (share for auth, state for runtime)
 RUN useradd -m -s /bin/bash klaudbiusz && \
-    chown -R klaudbiusz:klaudbiusz /workspace
+    mkdir -p /home/klaudbiusz/.local/share/opencode /home/klaudbiusz/.local/state && \
+    chown -R klaudbiusz:klaudbiusz /workspace /home/klaudbiusz/.local
 
 USER klaudbiusz
 

--- a/klaudbiusz/cli/generation/container_runner.py
+++ b/klaudbiusz/cli/generation/container_runner.py
@@ -36,6 +36,7 @@ def run(
                 wipe_db=False,
                 suppress_logs=False,
                 output_dir=output_dir,
+                model=model,
             )
             try:
                 metrics = builder.run(prompt, wipe_db=False)

--- a/klaudbiusz/cli/generation/dagger_run.py
+++ b/klaudbiusz/cli/generation/dagger_run.py
@@ -233,6 +233,16 @@ class DaggerAppGenerator:
         if gemini_key := os.environ.get("GEMINI_API_KEY"):
             container = container.with_env_variable("GOOGLE_GENERATIVE_AI_API_KEY", gemini_key)
 
+        # create opencode auth.json from env var for OpenRouter
+        # directories pre-created in Dockerfile
+        if openrouter_key := os.environ.get("OPENROUTER_API_KEY"):
+            auth_json = f'{{"openrouter": {{"type": "api", "key": "{openrouter_key}"}}}}'
+            container = container.with_new_file(
+                "/home/klaudbiusz/.local/share/opencode/auth.json",
+                auth_json,
+                owner="klaudbiusz:klaudbiusz",
+            )
+
         # mount databricks config for CLI authentication (OAuth profile)
         # container runs as 'klaudbiusz' user (see Dockerfile)
         databrickscfg = Path.home() / ".databrickscfg"

--- a/klaudbiusz/cli/generation/dagger_run.py
+++ b/klaudbiusz/cli/generation/dagger_run.py
@@ -219,6 +219,9 @@ class DaggerAppGenerator:
         # pass through env vars from host
         env_vars = [
             "ANTHROPIC_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
             "NEON_DATABASE_URL",
         ]
         for var in env_vars:

--- a/klaudbiusz/cli/generation/dagger_run.py
+++ b/klaudbiusz/cli/generation/dagger_run.py
@@ -229,6 +229,10 @@ class DaggerAppGenerator:
             if val := os.environ.get(var):
                 container = container.with_env_variable(var, val)
 
+        # map GEMINI_API_KEY to GOOGLE_GENERATIVE_AI_API_KEY (AI SDK uses this name)
+        if gemini_key := os.environ.get("GEMINI_API_KEY"):
+            container = container.with_env_variable("GOOGLE_GENERATIVE_AI_API_KEY", gemini_key)
+
         # mount databricks config for CLI authentication (OAuth profile)
         # container runs as 'klaudbiusz' user (see Dockerfile)
         databrickscfg = Path.home() / ".databrickscfg"

--- a/klaudbiusz/cli/generation/dagger_run.py
+++ b/klaudbiusz/cli/generation/dagger_run.py
@@ -216,12 +216,13 @@ class DaggerAppGenerator:
         # build from Dockerfile (leverages BuildKit cache)
         container = context.docker_build()
 
-        # pass through env vars from host
+        # pass through env vars from host (LLM providers + internal)
         env_vars = [
             "ANTHROPIC_API_KEY",
             "GEMINI_API_KEY",
             "GOOGLE_API_KEY",
             "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
             "NEON_DATABASE_URL",
         ]
         for var in env_vars:

--- a/klaudbiusz/cli/generation/local_run.py
+++ b/klaudbiusz/cli/generation/local_run.py
@@ -15,6 +15,7 @@ def run(
     prompt: str,
     app_name: str | None = None,
     output_dir: str | None = None,
+    model: str | None = None,
 ) -> dict[str, str | None]:
     """Run app generation locally (no Dagger).
 
@@ -25,9 +26,11 @@ def run(
         prompt: The prompt describing what to build
         app_name: Optional app name (default: timestamp-based)
         output_dir: Directory to store generated apps (default: ./app)
+        model: LLM model (e.g. "openrouter/moonshotai/kimi-k2.5")
 
     Usage:
         uv run python -m cli.generation.local_run "build dashboard"
+        uv run python -m cli.generation.local_run "build dashboard" --model="openrouter/moonshotai/kimi-k2.5"
     """
     if app_name is None:
         app_name = f"app-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
@@ -37,6 +40,7 @@ def run(
     builder = ClaudeAppBuilder(
         app_name=app_name,
         output_dir=str(resolved_output_dir),
+        model=model,
     )
     metrics = builder.run(prompt)
     app_dir = metrics.get("app_dir")

--- a/klaudbiusz/cli/generation_opencode/src/builder.ts
+++ b/klaudbiusz/cli/generation_opencode/src/builder.ts
@@ -18,12 +18,20 @@ Never deploy the app, just scaffold and build it.`;
 // 15 minutes timeout for event stream (generous for long-running generations)
 const EVENT_STREAM_TIMEOUT_MS = 15 * 60 * 1000;
 
+// per-message usage tracking (to handle multiple updates per message)
+interface MessageUsage {
+  cost: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
 export class OpencodeAppBuilder {
   private options: BuilderOptions;
   private client: OpencodeClient | null = null;
   private closeServer: (() => void) | null = null;
   private scaffoldedDir: string | null = null;
   private lastEventTime: number = Date.now();
+  private messageUsage: Map<string, MessageUsage> = new Map();
 
   constructor(options: BuilderOptions) {
     this.options = options;
@@ -57,6 +65,9 @@ export class OpencodeAppBuilder {
       output_tokens: 0,
       turns: 0,
     };
+
+    // reset message usage tracking
+    this.messageUsage.clear();
 
     // save original cwd and change to app directory so opencode picks up config
     const originalCwd = process.cwd();
@@ -175,7 +186,7 @@ Task: ${prompt}`;
         for await (const event of eventStream) {
           this.lastEventTime = Date.now();
           eventCount++;
-          this.handleEvent(event as Event);
+          this.handleEvent(event as Event, metrics);
 
           // check if prompt completed - we rely on session.idle
           if (event.type === "session.idle") {
@@ -185,6 +196,13 @@ Task: ${prompt}`;
       } finally {
         clearInterval(timeoutChecker);
         logTiming(`event loop (${eventCount} events)`, eventLoopStart);
+      }
+
+      // sum up usage from all messages
+      for (const usage of this.messageUsage.values()) {
+        metrics.cost_usd += usage.cost;
+        metrics.input_tokens += usage.inputTokens;
+        metrics.output_tokens += usage.outputTokens;
       }
 
       // wait for prompt to finish
@@ -237,11 +255,25 @@ Task: ${prompt}`;
     }
   }
 
-  private handleEvent(event: Event): void {
+  private handleEvent(event: Event, metrics: GenerationMetrics): void {
     switch (event.type) {
       case "session.error": {
         const err = event.properties;
         console.log(`❌ Session error: ${JSON.stringify(err)}`);
+        break;
+      }
+      case "message.updated": {
+        // track cost and tokens from assistant messages
+        // note: message.updated fires multiple times per message with cumulative values,
+        // so we store latest per message and sum at the end
+        const msg = event.properties.info;
+        if (msg.role === "assistant") {
+          this.messageUsage.set(msg.id, {
+            cost: msg.cost,
+            inputTokens: msg.tokens.input,
+            outputTokens: msg.tokens.output,
+          });
+        }
         break;
       }
       case "message.part.updated": {

--- a/klaudbiusz/cli/generation_opencode/src/builder.ts
+++ b/klaudbiusz/cli/generation_opencode/src/builder.ts
@@ -9,7 +9,9 @@ function logTiming(label: string, startMs: number): void {
   console.log(`⏱️  [${label}] ${elapsed}ms`);
 }
 
-const BASE_INSTRUCTIONS = `Scaffold, build, and test the app.
+const BASE_INSTRUCTIONS = `You are running in non-interactive mode. Never use the question tool - make reasonable assumptions instead.
+
+Scaffold, build, and test the app.
 Use data from Databricks when relevant.
 Be concise and to the point in your responses.
 Use up to 10 tools per call to speed up the process.
@@ -32,6 +34,7 @@ export class OpencodeAppBuilder {
   private scaffoldedDir: string | null = null;
   private lastEventTime: number = Date.now();
   private messageUsage: Map<string, MessageUsage> = new Map();
+  private loggedToolCalls: Set<string> = new Set(); // track logged tool calls to avoid duplicates
 
   constructor(options: BuilderOptions) {
     this.options = options;
@@ -64,8 +67,9 @@ export class OpencodeAppBuilder {
       turns: 0,
     };
 
-    // reset message usage tracking
+    // reset tracking state
     this.messageUsage.clear();
+    this.loggedToolCalls.clear();
 
     // save original cwd and change to app directory so opencode picks up config
     const originalCwd = process.cwd();
@@ -143,21 +147,6 @@ export class OpencodeAppBuilder {
           console.log(`  ${JSON.stringify(toolIds.data)}`);
         }
 
-        // get full tool list with provider to see MCP tools
-        const model = this.options.model ?? "anthropic/claude-sonnet-4-5-20250929";
-        const providerName = model.split("/")[0];
-        const modelName = model.split("/").slice(1).join("/");
-        const toolList = await client.tool.list({ query: { provider: providerName, model: modelName } });
-        console.log(`\n🔧 Full tool list (provider=${providerName}, model=${modelName}):`);
-        if (toolList.error) {
-          console.log(`  Error: ${JSON.stringify(toolList.error)}`);
-        } else {
-          // show full tool objects, not just names
-          console.log(`  Count: ${toolList.data.length}`);
-          for (const t of toolList.data) {
-            console.log(`  - ${JSON.stringify(t)}`);
-          }
-        }
         console.log("");
       }
 
@@ -314,20 +303,33 @@ Task: ${prompt}`;
           case "tool": {
             const toolName = part.tool;
             const state = part.state;
+            const partId = part.id;
 
-            // log tool state transitions
+            // log tool state transitions (only once per tool call)
             if ("status" in state && state.status === "running") {
-              const input = "input" in state ? state.input : undefined;
-              const inputStr = input ? JSON.stringify(input).slice(0, 150) : "";
-              console.log(`🔧 Tool: ${toolName}(${inputStr})`);
+              const runKey = `${partId}:running`;
+              if (!this.loggedToolCalls.has(runKey)) {
+                this.loggedToolCalls.add(runKey);
+                const input = "input" in state ? state.input : undefined;
+                const inputStr = input ? JSON.stringify(input).slice(0, 150) : "";
+                console.log(`🔧 Tool: ${toolName}(${inputStr})`);
+              }
             } else if ("status" in state && state.status === "completed") {
-              const output = "output" in state ? String(state.output).slice(0, 200) : "";
-              if (this.options.verbose) {
-                console.log(`✅ Result: ${output}`);
+              const completeKey = `${partId}:completed`;
+              if (!this.loggedToolCalls.has(completeKey)) {
+                this.loggedToolCalls.add(completeKey);
+                const output = "output" in state ? String(state.output).slice(0, 200) : "";
+                if (this.options.verbose) {
+                  console.log(`✅ Result: ${output}`);
+                }
               }
             } else if ("status" in state && state.status === "error") {
-              const error = "error" in state ? state.error : "unknown";
-              console.log(`❌ Tool error: ${error}`);
+              const errorKey = `${partId}:error`;
+              if (!this.loggedToolCalls.has(errorKey)) {
+                this.loggedToolCalls.add(errorKey);
+                const error = "error" in state ? state.error : "unknown";
+                console.log(`❌ Tool error: ${error}`);
+              }
             }
 
             // detect scaffold tool to track app_dir

--- a/klaudbiusz/cli/generation_opencode/src/builder.ts
+++ b/klaudbiusz/cli/generation_opencode/src/builder.ts
@@ -38,11 +38,9 @@ export class OpencodeAppBuilder {
   }
 
   private writeOpencodeConfig(configDir: string): void {
-    const model = this.options.model ?? "anthropic/claude-sonnet-4-5-20250929";
-
+    // minimal config - model is set via config.update() after server starts
     const config: OpencodeConfig = {
       $schema: "https://opencode.ai/config.json",
-      model,
     };
 
     fs.mkdirSync(configDir, { recursive: true });
@@ -75,21 +73,26 @@ export class OpencodeAppBuilder {
     try {
       process.chdir(appDir);
 
-      // start opencode server + client
+      // start opencode server + client (without model config - set via config.update after)
       let phaseStart = Date.now();
       const { client, server } = await createOpencode({
         port: this.options.port ?? 0, // 0 = auto-assign
-        config: {
-          model: this.options.model ?? "anthropic/claude-sonnet-4-5-20250929",
-        },
       });
       logTiming("createOpencode", phaseStart);
 
       this.client = client;
       this.closeServer = () => server.close();
 
+      // set model via config.update (passing in createOpencode config doesn't work for some providers)
+      const model = this.options.model ?? "anthropic/claude-sonnet-4-5-20250929";
+      const configResult = await client.config.update({ body: { model } });
+      if (configResult.error) {
+        console.log(`⚠️ Failed to set model ${model}: ${JSON.stringify(configResult.error)}`);
+      }
+
       if (this.options.verbose) {
         console.log(`OpenCode server running at ${server.url}`);
+        console.log(`Model: ${model}`);
       }
 
       // create session
@@ -109,16 +112,17 @@ export class OpencodeAppBuilder {
         console.log(`Created session: ${sessionId}`);
       }
 
-      // check provider auth status
+      // verify provider is connected
       const providerList = await client.provider.list();
-      if (providerList.error) {
-        console.log(`⚠️ Provider list error: ${JSON.stringify(providerList.error)}`);
-      } else {
-        const model = this.options.model ?? "anthropic/claude-sonnet-4-5-20250929";
+      if (!providerList.error) {
         const providerName = model.split("/")[0];
         const connected = providerList.data?.connected ?? [];
         const isConnected = connected.includes(providerName);
-        console.log(`🔑 Provider ${providerName} connected: ${isConnected} (all: ${connected.join(", ")})`);
+        if (!isConnected) {
+          console.log(`⚠️ Provider ${providerName} not connected. Available: ${connected.join(", ")}`);
+        } else if (this.options.verbose) {
+          console.log(`🔑 Provider ${providerName} connected`);
+        }
       }
 
       // debug: check MCP status and available tools
@@ -275,8 +279,10 @@ Task: ${prompt}`;
         break;
       }
       case "session.status": {
-        // always log session status to debug auth issues
-        console.log(`📊 Session status: ${JSON.stringify(event.properties)}`);
+        // log session status in verbose mode
+        if (this.options.verbose) {
+          console.log(`📊 Session status: ${JSON.stringify(event.properties)}`);
+        }
         break;
       }
       case "message.updated": {
@@ -341,8 +347,10 @@ Task: ${prompt}`;
         break;
       }
       default: {
-        // log all events for debugging auth issues
-        console.log(`📨 Event: ${event.type} ${JSON.stringify(event.properties).slice(0, 200)}`);
+        // log unknown events in verbose mode
+        if (this.options.verbose) {
+          console.log(`📨 Event: ${event.type} ${JSON.stringify(event.properties).slice(0, 200)}`);
+        }
       }
     }
   }

--- a/klaudbiusz/cli/generation_opencode/src/builder.ts
+++ b/klaudbiusz/cli/generation_opencode/src/builder.ts
@@ -109,6 +109,18 @@ export class OpencodeAppBuilder {
         console.log(`Created session: ${sessionId}`);
       }
 
+      // check provider auth status
+      const providerList = await client.provider.list();
+      if (providerList.error) {
+        console.log(`⚠️ Provider list error: ${JSON.stringify(providerList.error)}`);
+      } else {
+        const model = this.options.model ?? "anthropic/claude-sonnet-4-5-20250929";
+        const providerName = model.split("/")[0];
+        const connected = providerList.data?.connected ?? [];
+        const isConnected = connected.includes(providerName);
+        console.log(`🔑 Provider ${providerName} connected: ${isConnected} (all: ${connected.join(", ")})`);
+      }
+
       // debug: check MCP status and available tools
       if (this.options.verbose) {
         const mcpStatus = await client.mcp.status();
@@ -263,11 +275,8 @@ Task: ${prompt}`;
         break;
       }
       case "session.status": {
-        // log session status changes to debug auth issues
-        const status = event.properties;
-        if (this.options.verbose || "error" in status) {
-          console.log(`📊 Session status: ${JSON.stringify(status)}`);
-        }
+        // always log session status to debug auth issues
+        console.log(`📊 Session status: ${JSON.stringify(event.properties)}`);
         break;
       }
       case "message.updated": {

--- a/klaudbiusz/cli/generation_opencode/src/builder.ts
+++ b/klaudbiusz/cli/generation_opencode/src/builder.ts
@@ -332,10 +332,8 @@ Task: ${prompt}`;
         break;
       }
       default: {
-        // log unknown events in verbose mode for debugging
-        if (this.options.verbose) {
-          console.log(`📨 Event: ${event.type}`);
-        }
+        // log all events for debugging auth issues
+        console.log(`📨 Event: ${event.type} ${JSON.stringify(event.properties).slice(0, 200)}`);
       }
     }
   }

--- a/klaudbiusz/cli/generation_opencode/src/builder.ts
+++ b/klaudbiusz/cli/generation_opencode/src/builder.ts
@@ -262,6 +262,14 @@ Task: ${prompt}`;
         console.log(`❌ Session error: ${JSON.stringify(err)}`);
         break;
       }
+      case "session.status": {
+        // log session status changes to debug auth issues
+        const status = event.properties;
+        if (this.options.verbose || "error" in status) {
+          console.log(`📊 Session status: ${JSON.stringify(status)}`);
+        }
+        break;
+      }
       case "message.updated": {
         // track cost and tokens from assistant messages
         // note: message.updated fires multiple times per message with cumulative values,
@@ -322,6 +330,12 @@ Task: ${prompt}`;
       case "session.idle": {
         console.log("\n✅ Session complete");
         break;
+      }
+      default: {
+        // log unknown events in verbose mode for debugging
+        if (this.options.verbose) {
+          console.log(`📨 Event: ${event.type}`);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

### OpenCode backend improvements
- Track cost/tokens via `message.updated` events from OpenCode SDK
- Fix duplicate tool call logs (dedupe by partId)
- Add non-interactive mode to prevent question tool blocking

### OpenRouter support for Claude SDK
- Detect `openrouter/` model prefix and configure API env vars
- Add `--model` flag to `local_run.py`
- Disallow `AskUserQuestion` tool in non-interactive mode
- Remove skill-specific instructions (let model discover tools naturally)

### Type fixes
- Fix `mcp_servers` type annotation with proper `McpServerConfig` types

## Testing

```bash
# OpenRouter via Claude SDK (local)
uv run python -m cli.generation.local_run "build hello world" \
  --model="openrouter/moonshotai/kimi-k2.5"

# OpenRouter via Dagger
uv run python -m cli.generation.single_run "build hello world" \
  --model="openrouter/moonshotai/kimi-k2.5"
```

🤖 Generated with [Claude Code](https://claude.ai/code)