### PR TITLE
Improve MCP mode: auto-detect CLI, ban mcp__edda__ in skills mode

### DIFF
--- a/klaudbiusz/cli/generation/codegen.py
+++ b/klaudbiusz/cli/generation/codegen.py
@@ -87,22 +87,28 @@ class ClaudeAppBuilder:
         await self.tracker.init(wipe_db=self.wipe_db)
 
         # Use MCP tools directly if mcp_binary is provided, otherwise fall back to skills
+        # Log mode for debugging
         if self.mcp_binary:
+            logger.info(f"Mode: MCP (binary: {self.mcp_binary}, args: {self.mcp_args})")
             base_instructions = """Use the mcp__edda__scaffold_data_app tool to scaffold the app.
 Use the mcp__edda__databricks_* tools to explore data in Databricks when relevant.
 Be concise and to the point in your responses.
 Use up to 10 tools per call to speed up the process.
 Never deploy the app, just scaffold and build it.
 """
+            # MCP mode: allow mcp__edda__ tools
+            disallowed_tools = ["NotebookEdit", "WebSearch", "WebFetch"]
         else:
+            logger.info("Mode: Skills (no MCP binary configured)")
             base_instructions = """Use /databricks-apps skill to scaffold, build, and test the app.
 Use /databricks skill to explore data in Databricks when relevant.
 Be concise and to the point in your responses.
 Use up to 10 tools per call to speed up the process.
 Never deploy the app, just scaffold and build it.
+IMPORTANT: Do NOT use mcp__edda__* tools - they are not available. Use skills instead.
 """
-
-        disallowed_tools = ["NotebookEdit", "WebSearch", "WebFetch"]
+            # Skills mode: ban mcp__edda__ tools to prevent confusion
+            disallowed_tools = ["NotebookEdit", "WebSearch", "WebFetch", "mcp__edda__databricks_discover", "mcp__edda__invoke_databricks_cli", "mcp__edda__scaffold_data_app", "mcp__edda__databricks_configure_auth", "mcp__edda__databricks_query_sdk_docs", "mcp__edda__read_skill_file"]
 
         # When running as root (e.g., Databricks clusters), the CLI's
         # --dangerously-skip-permissions flag doesn't work by default.
@@ -115,7 +121,7 @@ Never deploy the app, just scaffold and build it.
             env_vars["IS_SANDBOX"] = "1"
 
         # Configure MCP server if binary is provided
-        mcp_servers: dict[str, dict[str, object]] = {}
+        mcp_servers = {}
         if self.mcp_binary:
             logger.info(f"Configuring MCP server: {self.mcp_binary} {self.mcp_args}")
             mcp_servers["edda"] = {
@@ -132,7 +138,7 @@ Never deploy the app, just scaffold and build it.
             },
             permission_mode="bypassPermissions",
             env=env_vars,
-            mcp_servers=mcp_servers if mcp_servers else {},
+            mcp_servers=mcp_servers,  # type: ignore[arg-type]
             disallowed_tools=disallowed_tools,
             setting_sources=["user", "project"],
             max_turns=75,

--- a/klaudbiusz/cli/generation/local_run.py
+++ b/klaudbiusz/cli/generation/local_run.py
@@ -1,5 +1,6 @@
 """Single app generation without Dagger (runs locally)."""
 
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -12,6 +13,39 @@ from cli.generation.codegen_multi import LiteLLMAppBuilder
 load_dotenv()
 
 
+def _find_databricks_cli() -> str | None:
+    """Auto-detect Databricks CLI binary with aitools/apps-mcp support.
+
+    MCP mode is faster than skills mode because tools are always available.
+    Skills require on-demand loading which adds latency per tool invocation.
+
+    Prefers local development builds that have experimental aitools command.
+    """
+    # Prefer local dev build with aitools support (check these first)
+    dev_candidates = [
+        Path.home() / "cli" / "cli",  # Local CLI repo build
+        Path.home() / "databricks-cli" / "cli",  # Alternative build location
+    ]
+
+    for path in dev_candidates:
+        if path.exists() and os.access(path, os.X_OK):
+            return str(path)
+
+    # Fall back to installed versions (may not have aitools)
+    import shutil
+
+    databricks_path = shutil.which("databricks")
+    if databricks_path:
+        return databricks_path
+
+    return None
+
+
+# Default MCP args for Databricks CLI aitools command
+# "experimental aitools mcp" or "experimental apps-mcp mcp" (apps-mcp is alias)
+DEFAULT_MCP_ARGS = ["experimental", "aitools", "mcp"]
+
+
 def run(
     prompt: str,
     app_name: str | None = None,
@@ -20,6 +54,7 @@ def run(
     mcp_binary: str | None = None,
     mcp_args: list[str] | None = None,
     output_dir: str | None = None,
+    no_mcp: bool = False,
 ) -> dict[str, str | None]:
     """Run app generation locally (no Dagger).
 
@@ -28,25 +63,47 @@ def run(
         app_name: Optional app name (default: timestamp-based)
         backend: Backend to use ("claude" or "litellm", default: "claude")
         model: LLM model (required if backend=litellm)
-        mcp_binary: Path to edda_mcp binary (optional for claude, required for litellm)
-        mcp_args: Optional list of args passed to the MCP server
+        mcp_binary: Path to Databricks CLI (auto-detected if not specified)
+        mcp_args: Args for MCP server (default: experimental aitools mcp)
         output_dir: Directory to store generated apps (default: ./app)
+        no_mcp: Force skills mode even if MCP binary is available
 
     Usage:
-        # Claude backend with skills (no MCP)
+        # Claude backend - auto-detects Databricks CLI for faster MCP execution
         uv run python -m cli.generation.local_run "build dashboard"
 
-        # Claude backend with MCP (faster, direct tool access)
-        uv run python -m cli.generation.local_run "build dashboard" --mcp_binary=/path/to/edda_mcp
+        # Force skills mode (slower, for testing)
+        uv run python -m cli.generation.local_run "build dashboard" --no_mcp
+
+        # Explicit CLI path
+        uv run python -m cli.generation.local_run "build dashboard" --mcp_binary=~/cli/cli
 
         # LiteLLM backend - requires MCP
-        uv run python -m cli.generation.local_run "build dashboard" --backend=litellm --model=gemini/gemini-2.5-pro --mcp_binary=/path/to/edda_mcp
+        uv run python -m cli.generation.local_run "build dashboard" --backend=litellm --model=gemini/gemini-2.5-pro
     """
+    # Auto-detect Databricks CLI if not specified (MCP is faster than skills)
+    if mcp_binary is None and not no_mcp:
+        mcp_binary = _find_databricks_cli()
+        if mcp_binary:
+            # Use default MCP args if not specified
+            if mcp_args is None:
+                mcp_args = DEFAULT_MCP_ARGS
+            print(f"🚀 Using MCP mode (faster): {mcp_binary} {' '.join(mcp_args)}")
+        else:
+            print("⚠️  Databricks CLI not found, falling back to skills mode (slower)")
+    elif no_mcp:
+        mcp_binary = None
+        print("📜 Using skills mode (--no_mcp flag)")
+    else:
+        if mcp_args is None:
+            mcp_args = DEFAULT_MCP_ARGS
+        print(f"🚀 Using MCP mode: {mcp_binary} {' '.join(mcp_args)}")
+
     if backend == "litellm":
         if not model:
             raise ValueError("--model is required when using --backend=litellm")
         if not mcp_binary:
-            raise ValueError("--mcp_binary is required for litellm backend")
+            raise ValueError("--mcp_binary is required for litellm backend (use --mcp_binary or ensure Databricks CLI is available)")
 
     if app_name is None:
         app_name = f"app-{datetime.now().strftime('%Y%m%d-%H%M%S')}"


### PR DESCRIPTION
## Summary
- Auto-detect Databricks CLI binary for MCP mode (faster than skills)
- Ban `mcp__edda__` tools when MCP not configured to prevent agent confusion
- Add `--no_mcp` flag for testing skills mode
- Log MCP vs Skills mode for debugging
- Use `DEFAULT_MCP_ARGS` for aitools command

Also includes screenshot capture commits from previous work.

## Test plan
- [x] Test local_run with auto-detected CLI
- [x] Test with `--no_mcp` flag to force skills mode
- [ ] Run full generation to verify MCP mode works

🤖 Generated with [Claude Code](https://claude.com/claude-code)