### PR TITLE
Add edda_forge — deterministic coding agent PoC

### DIFF
--- a/edda/Cargo.lock
+++ b/edda/Cargo.lock
@@ -1029,6 +1029,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "edda_forge"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dagger-sdk",
+ "edda_sandbox",
+ "eyre",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "edda_integrations"
 version = "0.1.0"
 dependencies = [

--- a/edda/Cargo.lock
+++ b/edda/Cargo.lock
@@ -1036,7 +1036,9 @@ dependencies = [
  "dagger-sdk",
  "edda_sandbox",
  "eyre",
+ "serde",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3538,6 +3540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,6 +4305,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.11.4",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -5133,6 +5185,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/edda/Cargo.toml
+++ b/edda/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["edda_agent", "edda_cli", "edda_mq", "edda_sandbox", "edda_integrations", "edda_mcp", "edda_screenshot", "edda_templates"]
+members = ["edda_agent", "edda_cli", "edda_mq", "edda_sandbox", "edda_integrations", "edda_mcp", "edda_screenshot", "edda_templates", "edda_forge"]
 
 [profile.dev]
 opt-level = 0

--- a/edda/edda_forge/Cargo.toml
+++ b/edda/edda_forge/Cargo.toml
@@ -14,4 +14,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }
 eyre = "0.6"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 dagger-sdk = "0.18.16"

--- a/edda/edda_forge/Cargo.toml
+++ b/edda/edda_forge/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "edda_forge"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "edda-forge"
+path = "src/main.rs"
+
+[dependencies]
+edda_sandbox = { path = "../edda_sandbox" }
+clap = { version = "4", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1", features = ["full"] }
+eyre = "0.6"
+dagger-sdk = "0.18.16"

--- a/edda/edda_forge/README.md
+++ b/edda/edda_forge/README.md
@@ -1,111 +1,113 @@
 # edda-forge
 
-Deterministic coding agent that generates Rust libraries from a prompt using Claude Code inside a Dagger container.
+Deterministic coding agent that generates code from a prompt using Claude Code inside a Dagger container. Config-driven — works with any language/stack via `forge.toml`.
 
 ## State machine
 
 ```
-Init → RewriteTask → CloneTemplate → WriteTests → CargoCheck(Tests)
-  → WriteCode → CargoCheck(Code) → RunTests → Review → RunBenchmark → Export → Done
+Init → RewriteTask → LoadTaskList → [WriteTests →] Validate(Tests)
+  → WriteCode → Validate(Code) → Review → Export → Done
 ```
 
 Failures backtrack with retry limits (default: 3 per edge):
-- `CargoCheck(Tests)` fails → retry `WriteTests`
-- `CargoCheck(Code)` fails → retry `WriteCode`
-- `RunTests` fails → retry `WriteCode`
+- `Validate(Tests)` fails → retry target specified by step's `retry_on_fail`
+- `Validate(Code)` fails → retry target specified by step's `retry_on_fail`
 - `Review` rejects → retry `WriteCode` with reviewer feedback
+
+In `Tests` phase, validation steps with `retry_on_fail = "write_code"` are skipped (code doesn't exist yet).
 
 ## Usage
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
-cargo run -p edda_forge -- --prompt "implement an LRU cache" --output ./out
+cargo run -p edda_forge -- --prompt "implement an LRU cache"
 ```
 
 Options:
 - `--prompt` — task description (required)
-- `--template` — path to custom project template (default: built-in)
-- `--output` — export directory (default: `./forge-output`)
+- `--config` — path to `forge.toml` config (default: `forge.toml`)
+- `--output` — output path (default: `./forge-output`; produces `.patch` by default)
+- `--export-dir` — export full directory instead of patch
 - `--max-retries` — retry limit per backtrack edge (default: 3)
-- `--image` — custom base Docker image (default: `rust:latest`)
 
-## Extending
+## Output
 
-### Custom template
+By default, edda-forge produces a **unified diff** (`.patch` file). A git baseline is committed after container setup, and the final diff captures all changes.
 
-The `--template` flag points to a Rust project directory that gets mounted into the container at `/app`. Claude generates code on top of it.
+```bash
+# default: patch output
+cargo run -p edda_forge -- --prompt "implement a stack" --output my-stack
+# → writes my-stack.patch
 
-```
-my-template/
-├── Cargo.toml
-├── src/
-│   └── lib.rs            # can be empty or contain scaffolding
-├── tests/
-│   └── integration.rs    # your pre-written tests
-└── benches/
-    └── bench.rs          # your pre-written benchmarks
+# directory export (previous behavior)
+cargo run -p edda_forge -- --prompt "implement a stack" --output ./out --export-dir
 ```
 
-### Custom tests
+## Configuration
 
-Put your tests at `tests/integration.rs`. The `WriteTests` step tells Claude to write tests there — if the file already has content, Claude sees it and extends it. To preserve your tests, add a marker:
+edda-forge is driven by `forge.toml`. When no config file is found, a built-in Rust default is used.
 
-```rust
-// === DO NOT MODIFY TESTS ABOVE THIS LINE ===
-```
-
-The crate name in `Cargo.toml` matters — tests import it. Default is `forge_project`.
-
-### Custom benchmarks
-
-Put criterion benchmarks in `benches/bench.rs`. `RunBenchmark` runs `cargo bench` — non-fatal, failures won't block export.
-
-Required in `Cargo.toml`:
 ```toml
-[dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+[container]
+image = "rust:latest"
+setup = ["apt-get update && apt-get install -y curl sudo git"]
+user = "forge"
+user_setup = """
+useradd -m -s /bin/bash forge \
+  && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+  && cp -r /usr/local/cargo /home/forge/.cargo \
+  && cp -r /usr/local/rustup /home/forge/.rustup \
+  && chown -R forge:forge /home/forge/.cargo /home/forge/.rustup
+"""
 
-[[bench]]
+[container.env]
+PATH = "/home/forge/.local/bin:/home/forge/.cargo/bin:..."
+CARGO_HOME = "/home/forge/.cargo"
+RUSTUP_HOME = "/home/forge/.rustup"
+
+[project]
+language = "rust"
+source = "."         # codebase to copy into container (relative to config file)
+workdir = "/app"
+
+[steps]
+write_tests = true   # include WriteTests phase
+
+[[steps.validate]]
+name = "check"
+command = "cargo check 2>&1"
+retry_on_fail = "write_tests"
+
+[[steps.validate]]
+name = "test"
+command = "cargo test 2>&1"
+retry_on_fail = "write_code"
+
+[[steps.validate]]
 name = "bench"
-harness = false
+command = "cargo bench 2>&1"
+retry_on_fail = "write_code"
 ```
 
-### Adding more test/bench files
+### Config fields
 
-```toml
-[[test]]
-name = "my_other_test"
-path = "tests/my_other_test.rs"
+**`[container]`** — Docker container setup
+- `image` — base Docker image
+- `setup` — list of shell commands run as root (install deps)
+- `user` — non-root user name (Claude CLI requires non-root)
+- `user_setup` — shell command to create the user
+- `env` — environment variables
 
-[[bench]]
-name = "my_other_bench"
-harness = false
-```
+**`[project]`** — project settings
+- `language` — used in AI prompts (e.g. "rust", "python", "typescript")
+- `source` — directory to copy into container (relative to config file)
+- `workdir` — working directory inside container
 
-### Custom Docker image
+**`[steps]`** — pipeline configuration
+- `write_tests` — whether to include the WriteTests phase
+- `validate` — ordered list of validation commands
 
-Use `--image` to provide a pre-built image. The image must have `cargo` and `rustc` available. The container setup will still:
-1. Install `curl` and `sudo` via `apt-get`
-2. Create a non-root `forge` user (Claude CLI refuses `--dangerously-skip-permissions` as root)
-3. Install Claude CLI
-4. Mount your template at `/app`
-
-```bash
-cargo run -p edda_forge -- \
-  --prompt "implement an LRU cache" \
-  --image my-registry/rust-with-extras:latest \
-  --template ./my-template
-```
-
-If your image already has a non-root user, Claude CLI, or extra dependencies, you'll need to modify `container.rs` — the setup steps are currently hardcoded.
-
-### Full example
-
-```bash
-cargo run -p edda_forge -- \
-  --prompt "implement a thread-safe LRU cache with TTL support" \
-  --template ./my-lru-template \
-  --image rust:1.84 \
-  --output ./lru-output \
-  --max-retries 5
-```
+**`[[steps.validate]]`** — validation step
+- `name` — step identifier (used in logs and retry tracking)
+- `command` — shell command to run
+- `retry_on_fail` — which AI step to retry: `"write_tests"` or `"write_code"`

--- a/edda/edda_forge/README.md
+++ b/edda/edda_forge/README.md
@@ -16,6 +16,8 @@ Failures backtrack with retry limits (default: 3 per edge):
 
 In `Tests` phase, validation steps with `retry_on_fail = "write_code"` are skipped (code doesn't exist yet).
 
+Stale `tasks.md` from previous runs is cleaned up automatically before the state machine starts. Review stage operates on the git diff, not individual files.
+
 ## Usage
 
 ```bash

--- a/edda/edda_forge/README.md
+++ b/edda/edda_forge/README.md
@@ -1,0 +1,111 @@
+# edda-forge
+
+Deterministic coding agent that generates Rust libraries from a prompt using Claude Code inside a Dagger container.
+
+## State machine
+
+```
+Init → RewriteTask → CloneTemplate → WriteTests → CargoCheck(Tests)
+  → WriteCode → CargoCheck(Code) → RunTests → Review → RunBenchmark → Export → Done
+```
+
+Failures backtrack with retry limits (default: 3 per edge):
+- `CargoCheck(Tests)` fails → retry `WriteTests`
+- `CargoCheck(Code)` fails → retry `WriteCode`
+- `RunTests` fails → retry `WriteCode`
+- `Review` rejects → retry `WriteCode` with reviewer feedback
+
+## Usage
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+cargo run -p edda_forge -- --prompt "implement an LRU cache" --output ./out
+```
+
+Options:
+- `--prompt` — task description (required)
+- `--template` — path to custom project template (default: built-in)
+- `--output` — export directory (default: `./forge-output`)
+- `--max-retries` — retry limit per backtrack edge (default: 3)
+- `--image` — custom base Docker image (default: `rust:latest`)
+
+## Extending
+
+### Custom template
+
+The `--template` flag points to a Rust project directory that gets mounted into the container at `/app`. Claude generates code on top of it.
+
+```
+my-template/
+├── Cargo.toml
+├── src/
+│   └── lib.rs            # can be empty or contain scaffolding
+├── tests/
+│   └── integration.rs    # your pre-written tests
+└── benches/
+    └── bench.rs          # your pre-written benchmarks
+```
+
+### Custom tests
+
+Put your tests at `tests/integration.rs`. The `WriteTests` step tells Claude to write tests there — if the file already has content, Claude sees it and extends it. To preserve your tests, add a marker:
+
+```rust
+// === DO NOT MODIFY TESTS ABOVE THIS LINE ===
+```
+
+The crate name in `Cargo.toml` matters — tests import it. Default is `forge_project`.
+
+### Custom benchmarks
+
+Put criterion benchmarks in `benches/bench.rs`. `RunBenchmark` runs `cargo bench` — non-fatal, failures won't block export.
+
+Required in `Cargo.toml`:
+```toml
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "bench"
+harness = false
+```
+
+### Adding more test/bench files
+
+```toml
+[[test]]
+name = "my_other_test"
+path = "tests/my_other_test.rs"
+
+[[bench]]
+name = "my_other_bench"
+harness = false
+```
+
+### Custom Docker image
+
+Use `--image` to provide a pre-built image. The image must have `cargo` and `rustc` available. The container setup will still:
+1. Install `curl` and `sudo` via `apt-get`
+2. Create a non-root `forge` user (Claude CLI refuses `--dangerously-skip-permissions` as root)
+3. Install Claude CLI
+4. Mount your template at `/app`
+
+```bash
+cargo run -p edda_forge -- \
+  --prompt "implement an LRU cache" \
+  --image my-registry/rust-with-extras:latest \
+  --template ./my-template
+```
+
+If your image already has a non-root user, Claude CLI, or extra dependencies, you'll need to modify `container.rs` — the setup steps are currently hardcoded.
+
+### Full example
+
+```bash
+cargo run -p edda_forge -- \
+  --prompt "implement a thread-safe LRU cache with TTL support" \
+  --template ./my-lru-template \
+  --image rust:1.84 \
+  --output ./lru-output \
+  --max-retries 5
+```

--- a/edda/edda_forge/forge.toml
+++ b/edda/edda_forge/forge.toml
@@ -1,0 +1,41 @@
+# Default Rust project configuration for edda-forge
+
+[container]
+image = "rust:latest"
+setup = ["apt-get update && apt-get install -y curl sudo git"]
+user = "forge"
+user_setup = """
+useradd -m -s /bin/bash forge \
+  && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+  && cp -r /usr/local/cargo /home/forge/.cargo \
+  && cp -r /usr/local/rustup /home/forge/.rustup \
+  && chown -R forge:forge /home/forge/.cargo /home/forge/.rustup
+"""
+
+[container.env]
+PATH = "/home/forge/.local/bin:/home/forge/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+CARGO_HOME = "/home/forge/.cargo"
+RUSTUP_HOME = "/home/forge/.rustup"
+
+[project]
+language = "rust"
+source = "."
+workdir = "/app"
+
+[steps]
+write_tests = true
+
+[[steps.validate]]
+name = "check"
+command = "cargo check 2>&1"
+retry_on_fail = "write_tests"
+
+[[steps.validate]]
+name = "test"
+command = "cargo test 2>&1"
+retry_on_fail = "write_code"
+
+[[steps.validate]]
+name = "bench"
+command = "cargo bench 2>&1"
+retry_on_fail = "write_code"

--- a/edda/edda_forge/src/config.rs
+++ b/edda/edda_forge/src/config.rs
@@ -1,0 +1,140 @@
+use eyre::{Result, bail};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ForgeConfig {
+    pub container: ContainerConfig,
+    pub project: ProjectConfig,
+    pub steps: StepsConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContainerConfig {
+    pub image: String,
+    pub setup: Vec<String>,
+    pub user: String,
+    pub user_setup: String,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProjectConfig {
+    pub language: String,
+    pub source: String,
+    pub workdir: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StepsConfig {
+    pub write_tests: bool,
+    pub validate: Vec<ValidateStep>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ValidateStep {
+    pub name: String,
+    pub command: String,
+    pub retry_on_fail: RetryTarget,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryTarget {
+    WriteTests,
+    WriteCode,
+}
+
+impl ForgeConfig {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| eyre::eyre!("failed to read config {}: {e}", path.display()))?;
+        let config: ForgeConfig = toml::from_str(&content)
+            .map_err(|e| eyre::eyre!("failed to parse config {}: {e}", path.display()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn default_rust() -> Self {
+        Self {
+            container: ContainerConfig {
+                image: "rust:latest".into(),
+                setup: vec!["apt-get update && apt-get install -y curl sudo git".into()],
+                user: "forge".into(),
+                user_setup: concat!(
+                    "useradd -m -s /bin/bash forge",
+                    " && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers",
+                    " && cp -r /usr/local/cargo /home/forge/.cargo",
+                    " && cp -r /usr/local/rustup /home/forge/.rustup",
+                    " && chown -R forge:forge /home/forge/.cargo /home/forge/.rustup",
+                )
+                .into(),
+                env: HashMap::from([
+                    ("PATH".into(), "/home/forge/.local/bin:/home/forge/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into()),
+                    ("CARGO_HOME".into(), "/home/forge/.cargo".into()),
+                    ("RUSTUP_HOME".into(), "/home/forge/.rustup".into()),
+                ]),
+            },
+            project: ProjectConfig {
+                language: "rust".into(),
+                source: ".".into(),
+                workdir: "/app".into(),
+            },
+            steps: StepsConfig {
+                write_tests: true,
+                validate: vec![
+                    ValidateStep {
+                        name: "check".into(),
+                        command: "cargo check 2>&1".into(),
+                        retry_on_fail: RetryTarget::WriteTests,
+                    },
+                    ValidateStep {
+                        name: "test".into(),
+                        command: "cargo test 2>&1".into(),
+                        retry_on_fail: RetryTarget::WriteCode,
+                    },
+                    ValidateStep {
+                        name: "bench".into(),
+                        command: "cargo bench 2>&1".into(),
+                        retry_on_fail: RetryTarget::WriteCode,
+                    },
+                ],
+            },
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.container.image.is_empty() {
+            bail!("container.image must not be empty");
+        }
+        if self.container.user.is_empty() {
+            bail!("container.user must not be empty");
+        }
+        if self.project.language.is_empty() {
+            bail!("project.language must not be empty");
+        }
+        if self.project.workdir.is_empty() {
+            bail!("project.workdir must not be empty");
+        }
+        if self.steps.validate.is_empty() {
+            bail!("steps.validate must have at least one step");
+        }
+        Ok(())
+    }
+}
+
+/// resolve source path relative to the config file's directory
+pub fn resolve_source_path(config: &ForgeConfig, config_dir: &Path) -> Result<PathBuf> {
+    let source = &config.project.source;
+    let resolved = config_dir.join(source);
+    if !resolved.exists() {
+        bail!(
+            "source path does not exist: {} (resolved from '{}')",
+            resolved.display(),
+            source
+        );
+    }
+    Ok(resolved)
+}

--- a/edda/edda_forge/src/container.rs
+++ b/edda/edda_forge/src/container.rs
@@ -7,6 +7,7 @@ pub async fn setup_container(
     client: DaggerConn,
     api_key: &str,
     template_path: &Path,
+    image: Option<&str>,
 ) -> Result<DaggerSandbox> {
     let template_dir = client
         .host()
@@ -32,7 +33,7 @@ pub async fn setup_container(
 
     let ctr = client
         .container()
-        .from("rust:latest")
+        .from(image.unwrap_or("rust:latest"))
         .with_exec(install_deps)
         .with_exec(create_user)
         .with_user("forge")

--- a/edda/edda_forge/src/container.rs
+++ b/edda/edda_forge/src/container.rs
@@ -1,0 +1,55 @@
+use dagger_sdk::DaggerConn;
+use edda_sandbox::DaggerSandbox;
+use eyre::{Result, bail};
+use std::path::Path;
+
+pub async fn setup_container(
+    client: DaggerConn,
+    api_key: &str,
+    template_path: &Path,
+) -> Result<DaggerSandbox> {
+    let template_dir = client
+        .host()
+        .directory(template_path.to_string_lossy().to_string());
+
+    let install_cmd: Vec<String> = vec![
+        "sh".into(),
+        "-c".into(),
+        "apt-get update && apt-get install -y curl && curl -fsSL https://claude.ai/install.sh | bash".into(),
+    ];
+
+    let ctr = client
+        .container()
+        .from("rust:latest")
+        .with_exec(install_cmd)
+        .with_env_variable("ANTHROPIC_API_KEY", api_key)
+        .with_directory("/app", template_dir)
+        .with_workdir("/app");
+
+    let sandbox = DaggerSandbox::from_container(ctr, client);
+    Ok(sandbox)
+}
+
+/// resolve template path: use provided path or fall back to embedded template
+pub fn resolve_template_path(custom_template: Option<&Path>) -> Result<std::path::PathBuf> {
+    match custom_template {
+        Some(p) => {
+            if !p.exists() {
+                bail!("template path does not exist: {}", p.display());
+            }
+            Ok(p.to_path_buf())
+        }
+        None => {
+            // use the embedded template relative to the crate
+            let manifest_dir = env!("CARGO_MANIFEST_DIR");
+            let template = Path::new(manifest_dir).join("template");
+            if !template.exists() {
+                bail!(
+                    "embedded template not found at {}",
+                    template.display()
+                );
+            }
+            Ok(template)
+        }
+    }
+}

--- a/edda/edda_forge/src/container.rs
+++ b/edda/edda_forge/src/container.rs
@@ -12,16 +12,34 @@ pub async fn setup_container(
         .host()
         .directory(template_path.to_string_lossy().to_string());
 
-    let install_cmd: Vec<String> = vec![
+    let install_deps: Vec<String> = vec![
         "sh".into(),
         "-c".into(),
-        "apt-get update && apt-get install -y curl && curl -fsSL https://claude.ai/install.sh | bash".into(),
+        "apt-get update && apt-get install -y curl sudo".into(),
+    ];
+
+    let create_user: Vec<String> = vec![
+        "sh".into(),
+        "-c".into(),
+        "useradd -m -s /bin/bash forge && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && cp -r /usr/local/cargo /home/forge/.cargo && cp -r /usr/local/rustup /home/forge/.rustup && chown -R forge:forge /home/forge/.cargo /home/forge/.rustup".into(),
+    ];
+
+    let install_claude: Vec<String> = vec![
+        "sh".into(),
+        "-c".into(),
+        "curl -fsSL https://claude.ai/install.sh | bash".into(),
     ];
 
     let ctr = client
         .container()
         .from("rust:latest")
-        .with_exec(install_cmd)
+        .with_exec(install_deps)
+        .with_exec(create_user)
+        .with_user("forge")
+        .with_env_variable("PATH", "/home/forge/.local/bin:/home/forge/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+        .with_env_variable("CARGO_HOME", "/home/forge/.cargo")
+        .with_env_variable("RUSTUP_HOME", "/home/forge/.rustup")
+        .with_exec(install_claude)
         .with_env_variable("ANTHROPIC_API_KEY", api_key)
         .with_directory("/app", template_dir)
         .with_workdir("/app");

--- a/edda/edda_forge/src/container.rs
+++ b/edda/edda_forge/src/container.rs
@@ -1,74 +1,56 @@
+use crate::config::ForgeConfig;
 use dagger_sdk::DaggerConn;
 use edda_sandbox::DaggerSandbox;
-use eyre::{Result, bail};
+use eyre::Result;
 use std::path::Path;
+
+fn sh(cmd: &str) -> Vec<String> {
+    vec!["sh".into(), "-c".into(), cmd.into()]
+}
 
 pub async fn setup_container(
     client: DaggerConn,
     api_key: &str,
-    template_path: &Path,
-    image: Option<&str>,
+    config: &ForgeConfig,
+    source_path: &Path,
 ) -> Result<DaggerSandbox> {
-    let template_dir = client
+    let source_dir = client
         .host()
-        .directory(template_path.to_string_lossy().to_string());
+        .directory(source_path.to_string_lossy().to_string());
 
-    let install_deps: Vec<String> = vec![
-        "sh".into(),
-        "-c".into(),
-        "apt-get update && apt-get install -y curl sudo".into(),
-    ];
+    let mut ctr = client.container().from(&config.container.image);
 
-    let create_user: Vec<String> = vec![
-        "sh".into(),
-        "-c".into(),
-        "useradd -m -s /bin/bash forge && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && cp -r /usr/local/cargo /home/forge/.cargo && cp -r /usr/local/rustup /home/forge/.rustup && chown -R forge:forge /home/forge/.cargo /home/forge/.rustup".into(),
-    ];
+    // run setup commands (as root)
+    for cmd in &config.container.setup {
+        ctr = ctr.with_exec(sh(cmd));
+    }
 
-    let install_claude: Vec<String> = vec![
-        "sh".into(),
-        "-c".into(),
-        "curl -fsSL https://claude.ai/install.sh | bash".into(),
-    ];
+    // create user
+    ctr = ctr.with_exec(sh(&config.container.user_setup));
 
-    let ctr = client
-        .container()
-        .from(image.unwrap_or("rust:latest"))
-        .with_exec(install_deps)
-        .with_exec(create_user)
-        .with_user("forge")
-        .with_env_variable("PATH", "/home/forge/.local/bin:/home/forge/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
-        .with_env_variable("CARGO_HOME", "/home/forge/.cargo")
-        .with_env_variable("RUSTUP_HOME", "/home/forge/.rustup")
-        .with_exec(install_claude)
+    // mount source and chown to user (still running as root)
+    let user = &config.container.user;
+    let workdir = &config.project.workdir;
+    ctr = ctr
+        .with_directory(workdir, source_dir)
+        .with_exec(sh(&format!("chown -R {user}:{user} {workdir}")));
+
+    // switch to user
+    ctr = ctr.with_user(user);
+
+    // set env vars
+    for (key, value) in &config.container.env {
+        ctr = ctr.with_env_variable(key, value);
+    }
+
+    // install claude CLI (always needed)
+    ctr = ctr.with_exec(sh("curl -fsSL https://claude.ai/install.sh | bash"));
+
+    // set API key and workdir
+    ctr = ctr
         .with_env_variable("ANTHROPIC_API_KEY", api_key)
-        .with_directory("/app", template_dir)
-        .with_workdir("/app");
+        .with_workdir(workdir);
 
     let sandbox = DaggerSandbox::from_container(ctr, client);
     Ok(sandbox)
-}
-
-/// resolve template path: use provided path or fall back to embedded template
-pub fn resolve_template_path(custom_template: Option<&Path>) -> Result<std::path::PathBuf> {
-    match custom_template {
-        Some(p) => {
-            if !p.exists() {
-                bail!("template path does not exist: {}", p.display());
-            }
-            Ok(p.to_path_buf())
-        }
-        None => {
-            // use the embedded template relative to the crate
-            let manifest_dir = env!("CARGO_MANIFEST_DIR");
-            let template = Path::new(manifest_dir).join("template");
-            if !template.exists() {
-                bail!(
-                    "embedded template not found at {}",
-                    template.display()
-                );
-            }
-            Ok(template)
-        }
-    }
 }

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -355,6 +355,7 @@ async fn step(
                     if retries.try_retry("review") {
                         warn!(
                             attempt = retries.count("review"),
+                            feedback = %feedback,
                             "review rejected, retrying WriteCode"
                         );
                         let task_list = read_task_list(sandbox).await;

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -100,17 +100,15 @@ async fn step(
         State::Init { prompt } => State::RewriteTask { prompt },
 
         State::RewriteTask { prompt } => match runner::rewrite_task(sandbox, &prompt).await {
-            Ok(_task_list) => State::CloneTemplate,
+            Ok(task_list) => State::LoadTaskList { task_list },
             Err(e) => State::Failed {
                 reason: format!("RewriteTask: {e}"),
             },
         },
 
-        State::CloneTemplate => {
+        State::LoadTaskList { task_list } => {
             // template is already mounted at /app during container setup
-            State::WriteTests {
-                task_list: read_task_list(sandbox).await,
-            }
+            State::WriteTests { task_list }
         }
 
         State::WriteTests { task_list } => {
@@ -310,7 +308,10 @@ async fn read_task_list(sandbox: &mut impl Sandbox) -> String {
     sandbox
         .read_file("/app/tasks.md")
         .await
-        .unwrap_or_else(|_| "no task list available".to_string())
+        .unwrap_or_else(|e| {
+            warn!(error = %e, "failed to read tasks.md");
+            "no task list available".to_string()
+        })
 }
 
 fn truncate_string(s: &str, max: usize) -> String {

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -19,9 +19,13 @@ struct Cli {
     #[arg(long)]
     prompt: String,
 
-    /// path to forge.toml config file
-    #[arg(long, default_value = "forge.toml")]
-    config: PathBuf,
+    /// path to forge.toml config file (looked up in source dir if not provided)
+    #[arg(long)]
+    config: Option<PathBuf>,
+
+    /// path to source directory (used when no config file is found)
+    #[arg(long)]
+    source: Option<PathBuf>,
 
     /// output path (default: patch file; with --export-dir: directory)
     #[arg(long, default_value = "./forge-output")]
@@ -50,33 +54,55 @@ async fn main() -> Result<()> {
     let api_key = std::env::var("ANTHROPIC_API_KEY")
         .map_err(|_| eyre::eyre!("ANTHROPIC_API_KEY not set"))?;
 
-    let forge_config = if cli.config.exists() {
-        info!(config = %cli.config.display(), "loading config");
-        ForgeConfig::load(&cli.config)?
-    } else {
-        info!("no config file found, using default Rust config");
-        ForgeConfig::default_rust()
+    // resolve config: explicit --config > forge.toml in --source dir > forge.toml in cwd > default
+    let config_path = match &cli.config {
+        Some(p) => {
+            if !p.exists() {
+                bail!("config file not found: {}", p.display());
+            }
+            Some(p.clone())
+        }
+        None => {
+            // look in --source dir first, then cwd
+            let candidates = cli
+                .source
+                .iter()
+                .map(|s| s.join("forge.toml"))
+                .chain(std::iter::once(PathBuf::from("forge.toml")));
+            candidates.into_iter().find(|p| p.exists())
+        }
     };
 
-    let config_dir = cli
-        .config
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."))
-        .to_path_buf();
-
-    let source_path = if forge_config.project.source == "." && !cli.config.exists() {
-        // no config file: use embedded template
-        let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let template = std::path::Path::new(manifest_dir).join("template");
-        if !template.exists() {
-            bail!(
-                "embedded template not found at {}",
-                template.display()
-            );
+    let (forge_config, config_dir) = match &config_path {
+        Some(p) => {
+            info!(config = %p.display(), "loading config");
+            let cfg = ForgeConfig::load(p)?;
+            let dir = p.parent().unwrap_or(std::path::Path::new(".")).to_path_buf();
+            (cfg, dir)
         }
-        template
-    } else {
-        config::resolve_source_path(&forge_config, &config_dir)?
+        None => {
+            info!("no config file found, using default Rust config");
+            (ForgeConfig::default_rust(), PathBuf::from("."))
+        }
+    };
+
+    let source_path = match &cli.source {
+        Some(p) => {
+            if !p.exists() {
+                bail!("source path does not exist: {}", p.display());
+            }
+            p.clone()
+        }
+        None if config_path.is_none() => {
+            // no config, no source: use embedded template
+            let manifest_dir = env!("CARGO_MANIFEST_DIR");
+            let template = std::path::Path::new(manifest_dir).join("template");
+            if !template.exists() {
+                bail!("embedded template not found at {}", template.display());
+            }
+            template
+        }
+        None => config::resolve_source_path(&forge_config, &config_dir)?,
     };
 
     info!(source = %source_path.display(), "resolved source path");

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -210,7 +210,7 @@ async fn step(
         State::RunTests => match runner::run_tests(sandbox).await {
             Ok(result) if result.exit_code == 0 => {
                 info!("all tests passed");
-                State::RunBenchmark
+                State::Review
             }
             Ok(result) => {
                 let error_output = format!("{}\n{}", result.stdout, result.stderr);
@@ -241,6 +241,43 @@ async fn step(
                 reason: format!("cargo test exec error: {e}"),
             },
         },
+
+        State::Review => {
+            let task_list = read_task_list(sandbox).await;
+            match runner::review(sandbox, &task_list).await {
+                Ok(runner::ReviewVerdict::Approved) => {
+                    info!("review approved");
+                    State::RunBenchmark
+                }
+                Ok(runner::ReviewVerdict::Rejected { feedback }) => {
+                    if retries.try_retry("review") {
+                        warn!(
+                            attempt = retries.count("review"),
+                            "review rejected, retrying WriteCode"
+                        );
+                        let task_list = read_task_list(sandbox).await;
+                        match runner::write_code(sandbox, &task_list, Some(&feedback)).await {
+                            Ok(()) => State::CargoCheck {
+                                phase: Phase::Code,
+                            },
+                            Err(e) => State::Failed {
+                                reason: format!("WriteCode retry after review rejection: {e}"),
+                            },
+                        }
+                    } else {
+                        State::Failed {
+                            reason: format!(
+                                "review rejected after max retries: {}",
+                                truncate_string(&feedback, 500)
+                            ),
+                        }
+                    }
+                }
+                Err(e) => State::Failed {
+                    reason: format!("review exec error: {e}"),
+                },
+            }
+        }
 
         State::RunBenchmark => {
             match runner::run_benchmark(sandbox).await {

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -1,8 +1,10 @@
+mod config;
 mod container;
 mod runner;
 mod state;
 
 use clap::Parser;
+use config::{ForgeConfig, RetryTarget};
 use edda_sandbox::Sandbox;
 use edda_sandbox::dagger::{ConnectOpts, Logger};
 use eyre::{Result, bail};
@@ -17,11 +19,11 @@ struct Cli {
     #[arg(long)]
     prompt: String,
 
-    /// path to custom Rust project template
-    #[arg(long)]
-    template: Option<PathBuf>,
+    /// path to forge.toml config file
+    #[arg(long, default_value = "forge.toml")]
+    config: PathBuf,
 
-    /// host directory for exported project
+    /// output path (default: patch file; with --export-dir: directory)
     #[arg(long, default_value = "./forge-output")]
     output: PathBuf,
 
@@ -29,9 +31,9 @@ struct Cli {
     #[arg(long, default_value_t = 3)]
     max_retries: usize,
 
-    /// custom base Docker image (must have cargo/rustc)
+    /// export full directory instead of generating a .patch file
     #[arg(long)]
-    image: Option<String>,
+    export_dir: bool,
 }
 
 #[tokio::main]
@@ -48,33 +50,102 @@ async fn main() -> Result<()> {
     let api_key = std::env::var("ANTHROPIC_API_KEY")
         .map_err(|_| eyre::eyre!("ANTHROPIC_API_KEY not set"))?;
 
-    let template_path = container::resolve_template_path(cli.template.as_deref())?;
-    info!(template = %template_path.display(), "resolved template");
+    let forge_config = if cli.config.exists() {
+        info!(config = %cli.config.display(), "loading config");
+        ForgeConfig::load(&cli.config)?
+    } else {
+        info!("no config file found, using default Rust config");
+        ForgeConfig::default_rust()
+    };
+
+    let config_dir = cli
+        .config
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_path_buf();
+
+    let source_path = if forge_config.project.source == "." && !cli.config.exists() {
+        // no config file: use embedded template
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let template = std::path::Path::new(manifest_dir).join("template");
+        if !template.exists() {
+            bail!(
+                "embedded template not found at {}",
+                template.display()
+            );
+        }
+        template
+    } else {
+        config::resolve_source_path(&forge_config, &config_dir)?
+    };
+
+    info!(source = %source_path.display(), "resolved source path");
 
     let output = cli.output.clone();
     let prompt = cli.prompt.clone();
     let max_retries = cli.max_retries;
-    let image = cli.image.clone();
+    let export_dir = cli.export_dir;
 
     let opts = ConnectOpts::new(Logger::Tracing, Some(600));
     opts.connect(move |client| async move {
         let mut sandbox =
-            container::setup_container(client, &api_key, &template_path, image.as_deref()).await?;
+            container::setup_container(client, &api_key, &forge_config, &source_path).await?;
+
+        // create git baseline for diff output
+        info!("creating git baseline commit");
+        let workdir = &forge_config.project.workdir;
+        let git_init = sandbox
+            .exec(&format!(
+                "git config --global --add safe.directory {workdir} && \
+                 git config --global init.defaultBranch main && \
+                 git config --global user.email forge@local && \
+                 git config --global user.name forge && \
+                 git init && git add -A && git commit -m baseline --allow-empty"
+            ))
+            .await?;
+        if git_init.exit_code != 0 {
+            warn!(
+                stderr = %git_init.stderr,
+                "git baseline setup failed (non-fatal)"
+            );
+        }
+
+        // clean up stale tasks.md from previous forge runs
+        let _ = sandbox.exec("rm -f tasks.md").await;
 
         let mut state = State::Init { prompt };
         let mut retries = RetryTracker::new(max_retries);
 
         while !state.is_terminal() {
             let old = format!("{state}");
-            state = step(state, &mut sandbox, &mut retries).await;
+            state = step(state, &mut sandbox, &mut retries, &forge_config).await;
             info!(from = %old, to = %state, "state transition");
         }
 
         match &state {
             State::Done => {
-                info!(output = %output.display(), "exporting project");
-                sandbox.export_directory("/app", &output.to_string_lossy()).await?;
-                info!("export complete");
+                if export_dir {
+                    info!(output = %output.display(), "exporting project directory");
+                    sandbox
+                        .export_directory("/app", &output.to_string_lossy())
+                        .await?;
+                    info!("directory export complete");
+                } else {
+                    let patch_path = if output.extension().is_some() {
+                        output.clone()
+                    } else {
+                        output.with_extension("patch")
+                    };
+                    info!(patch = %patch_path.display(), "generating patch");
+                    let diff_result = sandbox
+                        .exec("git add -A && git diff --cached")
+                        .await?;
+                    if diff_result.exit_code != 0 {
+                        bail!("git diff failed: {}", diff_result.stderr);
+                    }
+                    std::fs::write(&patch_path, &diff_result.stdout)?;
+                    info!(patch = %patch_path.display(), "patch written");
+                }
             }
             State::Failed { reason } => {
                 error!(%reason, "forge failed");
@@ -95,26 +166,38 @@ async fn step(
     state: State,
     sandbox: &mut impl Sandbox,
     retries: &mut RetryTracker,
+    config: &ForgeConfig,
 ) -> State {
+    let language = &config.project.language;
+
     match state {
         State::Init { prompt } => State::RewriteTask { prompt },
 
-        State::RewriteTask { prompt } => match runner::rewrite_task(sandbox, &prompt).await {
-            Ok(task_list) => State::LoadTaskList { task_list },
-            Err(e) => State::Failed {
-                reason: format!("RewriteTask: {e}"),
-            },
-        },
+        State::RewriteTask { prompt } => {
+            match runner::rewrite_task(sandbox, &prompt, language).await {
+                Ok(task_list) => State::LoadTaskList { task_list },
+                Err(e) => State::Failed {
+                    reason: format!("RewriteTask: {e}"),
+                },
+            }
+        }
 
         State::LoadTaskList { task_list } => {
-            // template is already mounted at /app during container setup
-            State::WriteTests { task_list }
+            if config.steps.write_tests {
+                State::WriteTests { task_list }
+            } else {
+                State::WriteCode {
+                    task_list,
+                    context: None,
+                }
+            }
         }
 
         State::WriteTests { task_list } => {
-            match runner::write_tests(sandbox, &task_list, None).await {
-                Ok(()) => State::CargoCheck {
+            match runner::write_tests(sandbox, &task_list, language, None).await {
+                Ok(()) => State::Validate {
                     phase: Phase::Tests,
+                    step_idx: 0,
                 },
                 Err(e) => State::Failed {
                     reason: format!("WriteTests: {e}"),
@@ -122,87 +205,11 @@ async fn step(
             }
         }
 
-        State::CargoCheck { phase } => {
-            match runner::cargo_check(sandbox).await {
-                Ok(result) if result.exit_code == 0 => match phase {
-                    Phase::Tests => State::WriteCode {
-                        task_list: read_task_list(sandbox).await,
-                        context: None,
-                    },
-                    Phase::Code => State::RunTests,
-                },
-                Ok(result) => {
-                    let error_output = format!("{}\n{}", result.stdout, result.stderr);
-                    match phase {
-                        Phase::Tests => {
-                            if retries.try_retry("cargo_check_tests") {
-                                warn!(
-                                    attempt = retries.count("cargo_check_tests"),
-                                    "cargo check failed after WriteTests, retrying"
-                                );
-                                let task_list = read_task_list(sandbox).await;
-                                // retry WriteTests with error context, then re-check
-                                match runner::write_tests(sandbox, &task_list, Some(&error_output))
-                                    .await
-                                {
-                                    Ok(()) => State::CargoCheck {
-                                        phase: Phase::Tests,
-                                    },
-                                    Err(e) => State::Failed {
-                                        reason: format!("WriteTests retry: {e}"),
-                                    },
-                                }
-                            } else {
-                                State::Failed {
-                                    reason: format!(
-                                        "cargo check (tests) failed after max retries: {}",
-                                        truncate_string(&error_output, 500)
-                                    ),
-                                }
-                            }
-                        }
-                        Phase::Code => {
-                            if retries.try_retry("cargo_check_code") {
-                                warn!(
-                                    attempt = retries.count("cargo_check_code"),
-                                    "cargo check failed after WriteCode, retrying"
-                                );
-                                let task_list = read_task_list(sandbox).await;
-                                match runner::write_code(
-                                    sandbox,
-                                    &task_list,
-                                    Some(&error_output),
-                                )
-                                .await
-                                {
-                                    Ok(()) => State::CargoCheck {
-                                        phase: Phase::Code,
-                                    },
-                                    Err(e) => State::Failed {
-                                        reason: format!("WriteCode retry: {e}"),
-                                    },
-                                }
-                            } else {
-                                State::Failed {
-                                    reason: format!(
-                                        "cargo check (code) failed after max retries: {}",
-                                        truncate_string(&error_output, 500)
-                                    ),
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(e) => State::Failed {
-                    reason: format!("cargo check exec error: {e}"),
-                },
-            }
-        }
-
         State::WriteCode { task_list, context } => {
-            match runner::write_code(sandbox, &task_list, context.as_deref()).await {
-                Ok(()) => State::CargoCheck {
+            match runner::write_code(sandbox, &task_list, language, context.as_deref()).await {
+                Ok(()) => State::Validate {
                     phase: Phase::Code,
+                    step_idx: 0,
                 },
                 Err(e) => State::Failed {
                     reason: format!("WriteCode: {e}"),
@@ -210,47 +217,113 @@ async fn step(
             }
         }
 
-        State::RunTests => match runner::run_tests(sandbox).await {
-            Ok(result) if result.exit_code == 0 => {
-                info!("all tests passed");
-                State::Review
-            }
-            Ok(result) => {
-                let error_output = format!("{}\n{}", result.stdout, result.stderr);
-                if retries.try_retry("run_tests") {
-                    warn!(
-                        attempt = retries.count("run_tests"),
-                        "tests failed, retrying WriteCode"
-                    );
-                    let task_list = read_task_list(sandbox).await;
-                    match runner::write_code(sandbox, &task_list, Some(&error_output)).await {
-                        Ok(()) => State::CargoCheck {
-                            phase: Phase::Code,
-                        },
-                        Err(e) => State::Failed {
-                            reason: format!("WriteCode retry after test failure: {e}"),
-                        },
-                    }
-                } else {
-                    State::Failed {
-                        reason: format!(
-                            "tests failed after max retries: {}",
-                            truncate_string(&error_output, 500)
-                        ),
+        State::Validate { phase, step_idx } => {
+            // find the next applicable step
+            let steps = &config.steps.validate;
+
+            // in Tests phase, skip steps with retry_on_fail = WriteCode (code doesn't exist yet)
+            let applicable_idx = (step_idx..steps.len()).find(|&i| match phase {
+                Phase::Tests => steps[i].retry_on_fail != RetryTarget::WriteCode,
+                Phase::Code => true,
+            });
+
+            let Some(idx) = applicable_idx else {
+                // no more steps — advance to next major state
+                return match phase {
+                    Phase::Tests => State::WriteCode {
+                        task_list: read_task_list(sandbox).await,
+                        context: None,
+                    },
+                    Phase::Code => State::Review,
+                };
+            };
+
+            let step = &steps[idx];
+
+            match runner::run_validate_step(sandbox, step).await {
+                Ok(result) if result.exit_code == 0 => {
+                    info!(step = %step.name, "validation step passed");
+                    // advance to next step
+                    State::Validate {
+                        phase,
+                        step_idx: idx + 1,
                     }
                 }
+                Ok(result) => {
+                    let error_output = format!("{}\n{}", result.stdout, result.stderr);
+                    let retry_edge = format!("validate_{}_{}", step.name, phase);
+                    // leak to get &'static str for retry tracker
+                    let retry_edge: &'static str = Box::leak(retry_edge.into_boxed_str());
+
+                    if retries.try_retry(retry_edge) {
+                        warn!(
+                            step = %step.name,
+                            attempt = retries.count(retry_edge),
+                            "validation failed, retrying"
+                        );
+
+                        let task_list = read_task_list(sandbox).await;
+
+                        match step.retry_on_fail {
+                            RetryTarget::WriteTests => {
+                                match runner::write_tests(
+                                    sandbox,
+                                    &task_list,
+                                    language,
+                                    Some(&error_output),
+                                )
+                                .await
+                                {
+                                    Ok(()) => State::Validate {
+                                        phase,
+                                        step_idx: 0,
+                                    },
+                                    Err(e) => State::Failed {
+                                        reason: format!("WriteTests retry: {e}"),
+                                    },
+                                }
+                            }
+                            RetryTarget::WriteCode => {
+                                match runner::write_code(
+                                    sandbox,
+                                    &task_list,
+                                    language,
+                                    Some(&error_output),
+                                )
+                                .await
+                                {
+                                    Ok(()) => State::Validate {
+                                        phase,
+                                        step_idx: 0,
+                                    },
+                                    Err(e) => State::Failed {
+                                        reason: format!("WriteCode retry: {e}"),
+                                    },
+                                }
+                            }
+                        }
+                    } else {
+                        State::Failed {
+                            reason: format!(
+                                "validation step '{}' failed after max retries: {}",
+                                step.name,
+                                truncate_string(&error_output, 500)
+                            ),
+                        }
+                    }
+                }
+                Err(e) => State::Failed {
+                    reason: format!("validation step '{}' exec error: {e}", step.name),
+                },
             }
-            Err(e) => State::Failed {
-                reason: format!("cargo test exec error: {e}"),
-            },
-        },
+        }
 
         State::Review => {
             let task_list = read_task_list(sandbox).await;
-            match runner::review(sandbox, &task_list).await {
+            match runner::review(sandbox, &task_list, language).await {
                 Ok(runner::ReviewVerdict::Approved) => {
                     info!("review approved");
-                    State::RunBenchmark
+                    State::Export
                 }
                 Ok(runner::ReviewVerdict::Rejected { feedback }) => {
                     if retries.try_retry("review") {
@@ -259,9 +332,12 @@ async fn step(
                             "review rejected, retrying WriteCode"
                         );
                         let task_list = read_task_list(sandbox).await;
-                        match runner::write_code(sandbox, &task_list, Some(&feedback)).await {
-                            Ok(()) => State::CargoCheck {
+                        match runner::write_code(sandbox, &task_list, language, Some(&feedback))
+                            .await
+                        {
+                            Ok(()) => State::Validate {
                                 phase: Phase::Code,
+                                step_idx: 0,
                             },
                             Err(e) => State::Failed {
                                 reason: format!("WriteCode retry after review rejection: {e}"),
@@ -280,22 +356,6 @@ async fn step(
                     reason: format!("review exec error: {e}"),
                 },
             }
-        }
-
-        State::RunBenchmark => {
-            match runner::run_benchmark(sandbox).await {
-                Ok(result) => {
-                    if result.exit_code != 0 {
-                        warn!("benchmarks failed (non-fatal): {}", result.stderr);
-                    } else {
-                        info!("benchmarks completed");
-                    }
-                }
-                Err(e) => {
-                    warn!("benchmark exec error (non-fatal): {e}");
-                }
-            }
-            State::Export
         }
 
         State::Export => State::Done,

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -28,6 +28,10 @@ struct Cli {
     /// max retries per backtrack edge
     #[arg(long, default_value_t = 3)]
     max_retries: usize,
+
+    /// custom base Docker image (must have cargo/rustc)
+    #[arg(long)]
+    image: Option<String>,
 }
 
 #[tokio::main]
@@ -50,11 +54,12 @@ async fn main() -> Result<()> {
     let output = cli.output.clone();
     let prompt = cli.prompt.clone();
     let max_retries = cli.max_retries;
+    let image = cli.image.clone();
 
     let opts = ConnectOpts::new(Logger::Tracing, Some(600));
     opts.connect(move |client| async move {
         let mut sandbox =
-            container::setup_container(client, &api_key, &template_path).await?;
+            container::setup_container(client, &api_key, &template_path, image.as_deref()).await?;
 
         let mut state = State::Init { prompt };
         let mut retries = RetryTracker::new(max_retries);

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -1,0 +1,280 @@
+mod container;
+mod runner;
+mod state;
+
+use clap::Parser;
+use edda_sandbox::Sandbox;
+use edda_sandbox::dagger::{ConnectOpts, Logger};
+use eyre::{Result, bail};
+use state::{Phase, RetryTracker, State};
+use std::path::PathBuf;
+use tracing::{error, info, warn};
+
+#[derive(Parser)]
+#[command(name = "edda-forge", about = "Deterministic coding agent")]
+struct Cli {
+    /// task description for code generation
+    #[arg(long)]
+    prompt: String,
+
+    /// path to custom Rust project template
+    #[arg(long)]
+    template: Option<PathBuf>,
+
+    /// host directory for exported project
+    #[arg(long, default_value = "./forge-output")]
+    output: PathBuf,
+
+    /// max retries per backtrack edge
+    #[arg(long, default_value_t = 3)]
+    max_retries: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("edda_forge=info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .map_err(|_| eyre::eyre!("ANTHROPIC_API_KEY not set"))?;
+
+    let template_path = container::resolve_template_path(cli.template.as_deref())?;
+    info!(template = %template_path.display(), "resolved template");
+
+    let output = cli.output.clone();
+    let prompt = cli.prompt.clone();
+    let max_retries = cli.max_retries;
+
+    let opts = ConnectOpts::new(Logger::Tracing, Some(600));
+    opts.connect(move |client| async move {
+        let mut sandbox =
+            container::setup_container(client, &api_key, &template_path).await?;
+
+        let mut state = State::Init { prompt };
+        let mut retries = RetryTracker::new(max_retries);
+
+        while !state.is_terminal() {
+            let old = format!("{state}");
+            state = step(state, &mut sandbox, &mut retries).await;
+            info!(from = %old, to = %state, "state transition");
+        }
+
+        match &state {
+            State::Done => {
+                info!(output = %output.display(), "exporting project");
+                sandbox.export_directory("/app", &output.to_string_lossy()).await?;
+                info!("export complete");
+            }
+            State::Failed { reason } => {
+                error!(%reason, "forge failed");
+                bail!("forge failed: {reason}");
+            }
+            _ => unreachable!(),
+        }
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| eyre::eyre!("dagger error: {e}"))?;
+
+    Ok(())
+}
+
+async fn step(
+    state: State,
+    sandbox: &mut impl Sandbox,
+    retries: &mut RetryTracker,
+) -> State {
+    match state {
+        State::Init { prompt } => State::RewriteTask { prompt },
+
+        State::RewriteTask { prompt } => match runner::rewrite_task(sandbox, &prompt).await {
+            Ok(_task_list) => State::CloneTemplate,
+            Err(e) => State::Failed {
+                reason: format!("RewriteTask: {e}"),
+            },
+        },
+
+        State::CloneTemplate => {
+            // template is already mounted at /app during container setup
+            State::WriteTests {
+                task_list: read_task_list(sandbox).await,
+            }
+        }
+
+        State::WriteTests { task_list } => {
+            match runner::write_tests(sandbox, &task_list, None).await {
+                Ok(()) => State::CargoCheck {
+                    phase: Phase::Tests,
+                },
+                Err(e) => State::Failed {
+                    reason: format!("WriteTests: {e}"),
+                },
+            }
+        }
+
+        State::CargoCheck { phase } => {
+            match runner::cargo_check(sandbox).await {
+                Ok(result) if result.exit_code == 0 => match phase {
+                    Phase::Tests => State::WriteCode {
+                        task_list: read_task_list(sandbox).await,
+                        context: None,
+                    },
+                    Phase::Code => State::RunTests,
+                },
+                Ok(result) => {
+                    let error_output = format!("{}\n{}", result.stdout, result.stderr);
+                    match phase {
+                        Phase::Tests => {
+                            if retries.try_retry("cargo_check_tests") {
+                                warn!(
+                                    attempt = retries.count("cargo_check_tests"),
+                                    "cargo check failed after WriteTests, retrying"
+                                );
+                                let task_list = read_task_list(sandbox).await;
+                                // retry WriteTests with error context, then re-check
+                                match runner::write_tests(sandbox, &task_list, Some(&error_output))
+                                    .await
+                                {
+                                    Ok(()) => State::CargoCheck {
+                                        phase: Phase::Tests,
+                                    },
+                                    Err(e) => State::Failed {
+                                        reason: format!("WriteTests retry: {e}"),
+                                    },
+                                }
+                            } else {
+                                State::Failed {
+                                    reason: format!(
+                                        "cargo check (tests) failed after max retries: {}",
+                                        truncate_string(&error_output, 500)
+                                    ),
+                                }
+                            }
+                        }
+                        Phase::Code => {
+                            if retries.try_retry("cargo_check_code") {
+                                warn!(
+                                    attempt = retries.count("cargo_check_code"),
+                                    "cargo check failed after WriteCode, retrying"
+                                );
+                                let task_list = read_task_list(sandbox).await;
+                                match runner::write_code(
+                                    sandbox,
+                                    &task_list,
+                                    Some(&error_output),
+                                )
+                                .await
+                                {
+                                    Ok(()) => State::CargoCheck {
+                                        phase: Phase::Code,
+                                    },
+                                    Err(e) => State::Failed {
+                                        reason: format!("WriteCode retry: {e}"),
+                                    },
+                                }
+                            } else {
+                                State::Failed {
+                                    reason: format!(
+                                        "cargo check (code) failed after max retries: {}",
+                                        truncate_string(&error_output, 500)
+                                    ),
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => State::Failed {
+                    reason: format!("cargo check exec error: {e}"),
+                },
+            }
+        }
+
+        State::WriteCode { task_list, context } => {
+            match runner::write_code(sandbox, &task_list, context.as_deref()).await {
+                Ok(()) => State::CargoCheck {
+                    phase: Phase::Code,
+                },
+                Err(e) => State::Failed {
+                    reason: format!("WriteCode: {e}"),
+                },
+            }
+        }
+
+        State::RunTests => match runner::run_tests(sandbox).await {
+            Ok(result) if result.exit_code == 0 => {
+                info!("all tests passed");
+                State::RunBenchmark
+            }
+            Ok(result) => {
+                let error_output = format!("{}\n{}", result.stdout, result.stderr);
+                if retries.try_retry("run_tests") {
+                    warn!(
+                        attempt = retries.count("run_tests"),
+                        "tests failed, retrying WriteCode"
+                    );
+                    let task_list = read_task_list(sandbox).await;
+                    match runner::write_code(sandbox, &task_list, Some(&error_output)).await {
+                        Ok(()) => State::CargoCheck {
+                            phase: Phase::Code,
+                        },
+                        Err(e) => State::Failed {
+                            reason: format!("WriteCode retry after test failure: {e}"),
+                        },
+                    }
+                } else {
+                    State::Failed {
+                        reason: format!(
+                            "tests failed after max retries: {}",
+                            truncate_string(&error_output, 500)
+                        ),
+                    }
+                }
+            }
+            Err(e) => State::Failed {
+                reason: format!("cargo test exec error: {e}"),
+            },
+        },
+
+        State::RunBenchmark => {
+            match runner::run_benchmark(sandbox).await {
+                Ok(result) => {
+                    if result.exit_code != 0 {
+                        warn!("benchmarks failed (non-fatal): {}", result.stderr);
+                    } else {
+                        info!("benchmarks completed");
+                    }
+                }
+                Err(e) => {
+                    warn!("benchmark exec error (non-fatal): {e}");
+                }
+            }
+            State::Export
+        }
+
+        State::Export => State::Done,
+
+        State::Done | State::Failed { .. } => state,
+    }
+}
+
+async fn read_task_list(sandbox: &mut impl Sandbox) -> String {
+    sandbox
+        .read_file("/app/tasks.md")
+        .await
+        .unwrap_or_else(|_| "no task list available".to_string())
+}
+
+fn truncate_string(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max])
+    }
+}

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -379,6 +379,19 @@ async fn step(
                         }
                     }
                 }
+                Ok(runner::ReviewVerdict::InvalidFormat) => {
+                    if retries.try_retry("review_format") {
+                        warn!(
+                            attempt = retries.count("review_format"),
+                            "review returned invalid format, retrying review"
+                        );
+                        State::Review
+                    } else {
+                        State::Failed {
+                            reason: "review returned invalid format after max retries".into(),
+                        }
+                    }
+                }
                 Err(e) => State::Failed {
                     reason: format!("review exec error: {e}"),
                 },

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -117,6 +117,50 @@ pub async fn write_code(
     Ok(())
 }
 
+pub enum ReviewVerdict {
+    Approved,
+    Rejected { feedback: String },
+}
+
+/// ask Claude to review the implementation
+pub async fn review(sandbox: &mut impl Sandbox, task_list: &str) -> Result<ReviewVerdict> {
+    let source = sandbox.read_file("/app/src/lib.rs").await?;
+    let tests = sandbox.read_file("/app/tests/integration.rs").await?;
+
+    let instruction = format!(
+        "You are a senior Rust code reviewer. \
+         Review the following implementation against the task list and tests.\n\n\
+         Task list:\n{task_list}\n\n\
+         Implementation:\n```rust\n{source}\n```\n\n\
+         Tests:\n```rust\n{tests}\n```\n\n\
+         Check for: correctness, idiomatic Rust, error handling, edge cases, API design.\n\n\
+         You MUST respond with exactly one of:\n\
+         - First line: APPROVED (if the code is acceptable)\n\
+         - First line: REJECTED (if changes are needed), followed by specific feedback on what to fix\n\n\
+         Do NOT write or modify any files. Only output your verdict."
+    );
+
+    info!("reviewing code");
+    let result = sandbox.exec(&claude_exec(&instruction)).await?;
+    check_exec(&result, "Review")?;
+
+    let output = result.stdout.trim().to_string();
+    if output.starts_with("APPROVED") {
+        Ok(ReviewVerdict::Approved)
+    } else if output.starts_with("REJECTED") {
+        let feedback = output
+            .strip_prefix("REJECTED")
+            .unwrap_or(&output)
+            .trim()
+            .to_string();
+        Ok(ReviewVerdict::Rejected { feedback })
+    } else {
+        // if the model didn't follow the format strictly, treat as rejection with full output as feedback
+        warn!("review output did not start with APPROVED/REJECTED, treating as rejection");
+        Ok(ReviewVerdict::Rejected { feedback: output })
+    }
+}
+
 /// run cargo check
 pub async fn cargo_check(sandbox: &mut impl Sandbox) -> Result<ExecResult> {
     info!("running cargo check");

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -173,9 +173,7 @@ pub async fn review(sandbox: &mut impl Sandbox, task_list: &str, language: &str)
             return Ok(ReviewVerdict::Approved);
         }
         if trimmed.starts_with("REJECTED") {
-            let feedback = output
-                .splitn(2, "REJECTED")
-                .nth(1)
+            let feedback = output.split_once("REJECTED").map(|x| x.1)
                 .unwrap_or("")
                 .trim()
                 .to_string();

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -1,3 +1,4 @@
+use crate::config::ValidateStep;
 use edda_sandbox::{ExecResult, Sandbox};
 use eyre::{Result, bail};
 use tracing::{debug, info, warn};
@@ -37,14 +38,18 @@ fn truncate(s: &str, max: usize) -> &str {
 }
 
 /// ask Claude to decompose the prompt into a task list (tasks.md)
-pub async fn rewrite_task(sandbox: &mut impl Sandbox, prompt: &str) -> Result<String> {
+pub async fn rewrite_task(
+    sandbox: &mut impl Sandbox,
+    prompt: &str,
+    language: &str,
+) -> Result<String> {
     let instruction = format!(
-        "You are working in /app, a Rust library project. \
+        "You are working in /app, a {language} project. \
          The user wants: {prompt}\n\n\
          Create a file called /app/tasks.md that breaks this down into a clear, \
-         numbered task list for implementing this as a Rust library. \
+         numbered task list for implementing this as a {language} library. \
          Focus on the public API, data structures, and key algorithms. \
-         Do NOT write any Rust code yet — only the task list."
+         Do NOT write any code yet — only the task list."
     );
 
     info!("rewriting task into tasks.md");
@@ -63,16 +68,16 @@ pub async fn rewrite_task(sandbox: &mut impl Sandbox, prompt: &str) -> Result<St
 pub async fn write_tests(
     sandbox: &mut impl Sandbox,
     task_list: &str,
+    language: &str,
     error_context: Option<&str>,
 ) -> Result<()> {
     let mut instruction = format!(
-        "You are working in /app, a Rust library project. \
+        "You are working in /app, a {language} project. \
          Here is the task list:\n\n{task_list}\n\n\
-         Write comprehensive tests in /app/tests/integration.rs that verify the \
-         public API described in the task list. \
+         Write comprehensive tests that verify the public API described in the task list. \
          Write ONLY tests — do not implement the library code. \
-         The tests should use the crate name `forge_project`. \
-         Make sure the test file compiles on its own (all necessary imports, etc.), \
+         Place tests in the conventional location for a {language} project. \
+         Make sure the test files compile/parse on their own (all necessary imports, etc.), \
          though tests will fail until the code is implemented."
     );
 
@@ -92,16 +97,15 @@ pub async fn write_tests(
 pub async fn write_code(
     sandbox: &mut impl Sandbox,
     task_list: &str,
+    language: &str,
     context: Option<&str>,
 ) -> Result<()> {
-    let tests = sandbox.read_file("/app/tests/integration.rs").await?;
-
     let mut instruction = format!(
-        "You are working in /app, a Rust library project. \
+        "You are working in /app, a {language} project. \
          Here is the task list:\n\n{task_list}\n\n\
-         Here are the tests that must pass:\n\n```rust\n{tests}\n```\n\n\
-         Implement the library in /app/src/lib.rs so that all tests pass. \
-         You may create additional modules under /app/src/ if needed. \
+         Read the existing test files in the project to understand what must pass. \
+         Implement the library so that all tests pass. \
+         You may create additional modules/files as needed. \
          Focus on correctness — make all tests pass."
     );
 
@@ -122,65 +126,79 @@ pub enum ReviewVerdict {
     Rejected { feedback: String },
 }
 
-/// ask Claude to review the implementation
-pub async fn review(sandbox: &mut impl Sandbox, task_list: &str) -> Result<ReviewVerdict> {
-    let source = sandbox.read_file("/app/src/lib.rs").await?;
-    let tests = sandbox.read_file("/app/tests/integration.rs").await?;
+/// ask Claude to review the diff
+pub async fn review(sandbox: &mut impl Sandbox, task_list: &str, language: &str) -> Result<ReviewVerdict> {
+    let diff_result = sandbox.exec("git add -A && git diff --cached").await?;
+    let diff = if diff_result.exit_code == 0 {
+        diff_result.stdout
+    } else {
+        warn!("git diff failed during review, falling back to file inspection");
+        String::new()
+    };
 
-    let instruction = format!(
-        "You are a senior Rust code reviewer. \
-         Review the following implementation against the task list and tests.\n\n\
-         Task list:\n{task_list}\n\n\
-         Implementation:\n```rust\n{source}\n```\n\n\
-         Tests:\n```rust\n{tests}\n```\n\n\
-         Check for: correctness, idiomatic Rust, error handling, edge cases, API design.\n\n\
-         You MUST respond with exactly one of:\n\
-         - First line: APPROVED (if the code is acceptable)\n\
-         - First line: REJECTED (if changes are needed), followed by specific feedback on what to fix\n\n\
-         Do NOT write or modify any files. Only output your verdict."
-    );
+    let instruction = if diff.is_empty() {
+        format!(
+            "You are a senior {language} code reviewer. \
+             You are working in /app. Read the source code and test files yourself.\n\n\
+             Review the implementation against this task list:\n{task_list}\n\n\
+             Check for: correctness, idiomatic {language}, error handling, edge cases, API design.\n\n\
+             IMPORTANT: Your response MUST contain exactly one of these words on its own line:\n\
+             APPROVED — if the code is acceptable\n\
+             REJECTED — if changes are needed, followed by specific feedback on what to fix\n\n\
+             Do NOT write or modify any files."
+        )
+    } else {
+        format!(
+            "You are a senior {language} code reviewer. \
+             Review the following diff against the task list.\n\n\
+             Task list:\n{task_list}\n\n\
+             Diff:\n```diff\n{diff}\n```\n\n\
+             Check for: correctness, idiomatic {language}, error handling, edge cases, API design.\n\n\
+             IMPORTANT: Your response MUST contain exactly one of these words on its own line:\n\
+             APPROVED — if the code is acceptable\n\
+             REJECTED — if changes are needed, followed by specific feedback on what to fix\n\n\
+             Do NOT write or modify any files."
+        )
+    };
 
     info!("reviewing code");
     let result = sandbox.exec(&claude_exec(&instruction)).await?;
     check_exec(&result, "Review")?;
 
     let output = result.stdout.trim().to_string();
-    if output.starts_with("APPROVED") {
-        Ok(ReviewVerdict::Approved)
-    } else if output.starts_with("REJECTED") {
-        let feedback = output
-            .strip_prefix("REJECTED")
-            .unwrap_or(&output)
-            .trim()
-            .to_string();
-        Ok(ReviewVerdict::Rejected { feedback })
-    } else {
-        // if the model didn't follow the format strictly, treat as rejection with full output as feedback
-        warn!("review output did not start with APPROVED/REJECTED, treating as rejection");
-        Ok(ReviewVerdict::Rejected { feedback: output })
+    // scan lines for verdict — model doesn't always put it on the first line
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("APPROVED") {
+            return Ok(ReviewVerdict::Approved);
+        }
+        if trimmed.starts_with("REJECTED") {
+            let feedback = output
+                .splitn(2, "REJECTED")
+                .nth(1)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            return Ok(ReviewVerdict::Rejected { feedback });
+        }
     }
+
+    // no explicit verdict found — treat as rejection
+    warn!("review output did not contain APPROVED/REJECTED, treating as rejection");
+    Ok(ReviewVerdict::Rejected { feedback: output })
 }
 
-/// run cargo check
-pub async fn cargo_check(sandbox: &mut impl Sandbox) -> Result<ExecResult> {
-    info!("running cargo check");
-    let result = sandbox.exec("cargo check 2>&1").await?;
-    debug!(exit_code = result.exit_code, "cargo check finished");
-    Ok(result)
-}
-
-/// run cargo test
-pub async fn run_tests(sandbox: &mut impl Sandbox) -> Result<ExecResult> {
-    info!("running cargo test");
-    let result = sandbox.exec("cargo test 2>&1").await?;
-    debug!(exit_code = result.exit_code, "cargo test finished");
-    Ok(result)
-}
-
-/// run cargo bench (non-fatal — we just log the output)
-pub async fn run_benchmark(sandbox: &mut impl Sandbox) -> Result<ExecResult> {
-    info!("running cargo bench");
-    let result = sandbox.exec("cargo bench 2>&1").await?;
-    debug!(exit_code = result.exit_code, "cargo bench finished");
+/// run a single validation step
+pub async fn run_validate_step(
+    sandbox: &mut impl Sandbox,
+    step: &ValidateStep,
+) -> Result<ExecResult> {
+    info!(step = %step.name, command = %step.command, "running validation step");
+    let result = sandbox.exec(&step.command).await?;
+    debug!(
+        step = %step.name,
+        exit_code = result.exit_code,
+        "validation step finished"
+    );
     Ok(result)
 }

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -124,6 +124,7 @@ pub async fn write_code(
 pub enum ReviewVerdict {
     Approved,
     Rejected { feedback: String },
+    InvalidFormat,
 }
 
 /// ask Claude to review the diff
@@ -136,28 +137,24 @@ pub async fn review(sandbox: &mut impl Sandbox, task_list: &str, language: &str)
         String::new()
     };
 
+    let verdict_format = "\n\nRespond ONLY with one of:\n\
+         APPROVED\n\
+         REJECTED: <short reason>\n\n\
+         No analysis, no markdown, no explanation — just the verdict line.";
+
     let instruction = if diff.is_empty() {
         format!(
-            "You are a senior {language} code reviewer. \
-             You are working in /app. Read the source code and test files yourself.\n\n\
-             Review the implementation against this task list:\n{task_list}\n\n\
-             Check for: correctness, idiomatic {language}, error handling, edge cases, API design.\n\n\
-             IMPORTANT: Your response MUST contain exactly one of these words on its own line:\n\
-             APPROVED — if the code is acceptable\n\
-             REJECTED — if changes are needed, followed by specific feedback on what to fix\n\n\
-             Do NOT write or modify any files."
+            "You are a {language} code reviewer. \
+             You are working in /app. Read the source code yourself.\n\n\
+             Task list:\n{task_list}\n\n\
+             Check for correctness and bugs only. Do NOT write or modify any files.{verdict_format}"
         )
     } else {
         format!(
-            "You are a senior {language} code reviewer. \
-             Review the following diff against the task list.\n\n\
+            "You are a {language} code reviewer. Review this diff.\n\n\
              Task list:\n{task_list}\n\n\
              Diff:\n```diff\n{diff}\n```\n\n\
-             Check for: correctness, idiomatic {language}, error handling, edge cases, API design.\n\n\
-             IMPORTANT: Your response MUST contain exactly one of these words on its own line:\n\
-             APPROVED — if the code is acceptable\n\
-             REJECTED — if changes are needed, followed by specific feedback on what to fix\n\n\
-             Do NOT write or modify any files."
+             Check for correctness and bugs only. Do NOT write or modify any files.{verdict_format}"
         )
     };
 
@@ -181,9 +178,9 @@ pub async fn review(sandbox: &mut impl Sandbox, task_list: &str, language: &str)
         }
     }
 
-    // no explicit verdict found — treat as rejection
-    warn!("review output did not contain APPROVED/REJECTED, treating as rejection");
-    Ok(ReviewVerdict::Rejected { feedback: output })
+    // no explicit verdict found — invalid format, should retry review itself
+    warn!("review output did not contain APPROVED/REJECTED");
+    Ok(ReviewVerdict::InvalidFormat)
 }
 
 /// run a single validation step

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -1,0 +1,142 @@
+use edda_sandbox::{ExecResult, Sandbox};
+use eyre::{Result, bail};
+use tracing::{debug, info, warn};
+
+const CLAUDE_CMD: &str = "claude -p";
+const CLAUDE_FLAGS: &str = "--dangerously-skip-permissions";
+
+fn claude_exec(prompt: &str) -> String {
+    // escape single quotes in prompt for shell safety
+    let escaped = prompt.replace('\'', "'\\''");
+    format!("{CLAUDE_CMD} '{escaped}' {CLAUDE_FLAGS}")
+}
+
+fn check_exec(result: &ExecResult, step: &str) -> Result<()> {
+    if result.exit_code != 0 {
+        warn!(
+            step,
+            exit_code = result.exit_code,
+            stderr_len = result.stderr.len(),
+            "step failed"
+        );
+        bail!(
+            "{step} failed (exit {}): {}",
+            result.exit_code,
+            truncate(&result.stderr, 2000)
+        );
+    }
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        &s[..max]
+    }
+}
+
+/// ask Claude to decompose the prompt into a task list (tasks.md)
+pub async fn rewrite_task(sandbox: &mut impl Sandbox, prompt: &str) -> Result<String> {
+    let instruction = format!(
+        "You are working in /app, a Rust library project. \
+         The user wants: {prompt}\n\n\
+         Create a file called /app/tasks.md that breaks this down into a clear, \
+         numbered task list for implementing this as a Rust library. \
+         Focus on the public API, data structures, and key algorithms. \
+         Do NOT write any Rust code yet — only the task list."
+    );
+
+    info!("rewriting task into tasks.md");
+    let result = sandbox.exec(&claude_exec(&instruction)).await?;
+    check_exec(&result, "RewriteTask")?;
+
+    let task_list = sandbox.read_file("/app/tasks.md").await?;
+    if task_list.trim().is_empty() {
+        bail!("RewriteTask produced empty tasks.md");
+    }
+    debug!(task_list_len = task_list.len(), "tasks.md created");
+    Ok(task_list)
+}
+
+/// ask Claude to write tests based on the task list
+pub async fn write_tests(
+    sandbox: &mut impl Sandbox,
+    task_list: &str,
+    error_context: Option<&str>,
+) -> Result<()> {
+    let mut instruction = format!(
+        "You are working in /app, a Rust library project. \
+         Here is the task list:\n\n{task_list}\n\n\
+         Write comprehensive tests in /app/tests/integration.rs that verify the \
+         public API described in the task list. \
+         Write ONLY tests — do not implement the library code. \
+         The tests should use the crate name `forge_project`. \
+         Make sure the test file compiles on its own (all necessary imports, etc.), \
+         though tests will fail until the code is implemented."
+    );
+
+    if let Some(ctx) = error_context {
+        instruction.push_str(&format!(
+            "\n\nPrevious attempt failed with this error — fix the issues:\n{ctx}"
+        ));
+    }
+
+    info!("writing tests");
+    let result = sandbox.exec(&claude_exec(&instruction)).await?;
+    check_exec(&result, "WriteTests")?;
+    Ok(())
+}
+
+/// ask Claude to implement the code
+pub async fn write_code(
+    sandbox: &mut impl Sandbox,
+    task_list: &str,
+    context: Option<&str>,
+) -> Result<()> {
+    let tests = sandbox.read_file("/app/tests/integration.rs").await?;
+
+    let mut instruction = format!(
+        "You are working in /app, a Rust library project. \
+         Here is the task list:\n\n{task_list}\n\n\
+         Here are the tests that must pass:\n\n```rust\n{tests}\n```\n\n\
+         Implement the library in /app/src/lib.rs so that all tests pass. \
+         You may create additional modules under /app/src/ if needed. \
+         Focus on correctness — make all tests pass."
+    );
+
+    if let Some(ctx) = context {
+        instruction.push_str(&format!(
+            "\n\nPrevious attempt failed with this error — fix the issues:\n{ctx}"
+        ));
+    }
+
+    info!("writing code");
+    let result = sandbox.exec(&claude_exec(&instruction)).await?;
+    check_exec(&result, "WriteCode")?;
+    Ok(())
+}
+
+/// run cargo check
+pub async fn cargo_check(sandbox: &mut impl Sandbox) -> Result<ExecResult> {
+    info!("running cargo check");
+    let result = sandbox.exec("cargo check 2>&1").await?;
+    debug!(exit_code = result.exit_code, "cargo check finished");
+    Ok(result)
+}
+
+/// run cargo test
+pub async fn run_tests(sandbox: &mut impl Sandbox) -> Result<ExecResult> {
+    info!("running cargo test");
+    let result = sandbox.exec("cargo test 2>&1").await?;
+    debug!(exit_code = result.exit_code, "cargo test finished");
+    Ok(result)
+}
+
+/// run cargo bench (non-fatal — we just log the output)
+pub async fn run_benchmark(sandbox: &mut impl Sandbox) -> Result<ExecResult> {
+    info!("running cargo bench");
+    let result = sandbox.exec("cargo bench 2>&1").await?;
+    debug!(exit_code = result.exit_code, "cargo bench finished");
+    Ok(result)
+}

--- a/edda/edda_forge/src/state.rs
+++ b/edda/edda_forge/src/state.rs
@@ -30,16 +30,15 @@ pub enum State {
     WriteTests {
         task_list: String,
     },
-    CargoCheck {
-        phase: Phase,
-    },
     WriteCode {
         task_list: String,
         context: Option<String>,
     },
-    RunTests,
+    Validate {
+        phase: Phase,
+        step_idx: usize,
+    },
     Review,
-    RunBenchmark,
     Export,
     Done,
     Failed {
@@ -60,7 +59,6 @@ impl fmt::Display for State {
             State::RewriteTask { .. } => write!(f, "RewriteTask"),
             State::LoadTaskList { .. } => write!(f, "LoadTaskList"),
             State::WriteTests { .. } => write!(f, "WriteTests"),
-            State::CargoCheck { phase } => write!(f, "CargoCheck({})", phase),
             State::WriteCode { context, .. } => {
                 if context.is_some() {
                     write!(f, "WriteCode(retry)")
@@ -68,9 +66,10 @@ impl fmt::Display for State {
                     write!(f, "WriteCode")
                 }
             }
-            State::RunTests => write!(f, "RunTests"),
+            State::Validate { phase, step_idx } => {
+                write!(f, "Validate({}, step={})", phase, step_idx)
+            }
             State::Review => write!(f, "Review"),
-            State::RunBenchmark => write!(f, "RunBenchmark"),
             State::Export => write!(f, "Export"),
             State::Done => write!(f, "Done"),
             State::Failed { reason } => write!(f, "Failed({})", reason),

--- a/edda/edda_forge/src/state.rs
+++ b/edda/edda_forge/src/state.rs
@@ -25,6 +25,7 @@ pub enum State {
     CargoCheck { phase: Phase },
     WriteCode { task_list: String, context: Option<String> },
     RunTests,
+    Review,
     RunBenchmark,
     Export,
     Done,
@@ -53,6 +54,7 @@ impl fmt::Display for State {
                 }
             }
             State::RunTests => write!(f, "RunTests"),
+            State::Review => write!(f, "Review"),
             State::RunBenchmark => write!(f, "RunBenchmark"),
             State::Export => write!(f, "Export"),
             State::Done => write!(f, "Done"),

--- a/edda/edda_forge/src/state.rs
+++ b/edda/edda_forge/src/state.rs
@@ -18,18 +18,33 @@ impl fmt::Display for Phase {
 
 #[derive(Debug, Clone)]
 pub enum State {
-    Init { prompt: String },
-    RewriteTask { prompt: String },
-    CloneTemplate,
-    WriteTests { task_list: String },
-    CargoCheck { phase: Phase },
-    WriteCode { task_list: String, context: Option<String> },
+    Init {
+        prompt: String,
+    },
+    RewriteTask {
+        prompt: String,
+    },
+    LoadTaskList {
+        task_list: String,
+    },
+    WriteTests {
+        task_list: String,
+    },
+    CargoCheck {
+        phase: Phase,
+    },
+    WriteCode {
+        task_list: String,
+        context: Option<String>,
+    },
     RunTests,
     Review,
     RunBenchmark,
     Export,
     Done,
-    Failed { reason: String },
+    Failed {
+        reason: String,
+    },
 }
 
 impl State {
@@ -43,7 +58,7 @@ impl fmt::Display for State {
         match self {
             State::Init { .. } => write!(f, "Init"),
             State::RewriteTask { .. } => write!(f, "RewriteTask"),
-            State::CloneTemplate => write!(f, "CloneTemplate"),
+            State::LoadTaskList { .. } => write!(f, "LoadTaskList"),
             State::WriteTests { .. } => write!(f, "WriteTests"),
             State::CargoCheck { phase } => write!(f, "CargoCheck({})", phase),
             State::WriteCode { context, .. } => {

--- a/edda/edda_forge/src/state.rs
+++ b/edda/edda_forge/src/state.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub enum Phase {
+    Tests,
+    Code,
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Phase::Tests => write!(f, "Tests"),
+            Phase::Code => write!(f, "Code"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum State {
+    Init { prompt: String },
+    RewriteTask { prompt: String },
+    CloneTemplate,
+    WriteTests { task_list: String },
+    CargoCheck { phase: Phase },
+    WriteCode { task_list: String, context: Option<String> },
+    RunTests,
+    RunBenchmark,
+    Export,
+    Done,
+    Failed { reason: String },
+}
+
+impl State {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, State::Done | State::Failed { .. })
+    }
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            State::Init { .. } => write!(f, "Init"),
+            State::RewriteTask { .. } => write!(f, "RewriteTask"),
+            State::CloneTemplate => write!(f, "CloneTemplate"),
+            State::WriteTests { .. } => write!(f, "WriteTests"),
+            State::CargoCheck { phase } => write!(f, "CargoCheck({})", phase),
+            State::WriteCode { context, .. } => {
+                if context.is_some() {
+                    write!(f, "WriteCode(retry)")
+                } else {
+                    write!(f, "WriteCode")
+                }
+            }
+            State::RunTests => write!(f, "RunTests"),
+            State::RunBenchmark => write!(f, "RunBenchmark"),
+            State::Export => write!(f, "Export"),
+            State::Done => write!(f, "Done"),
+            State::Failed { reason } => write!(f, "Failed({})", reason),
+        }
+    }
+}
+
+/// tracks retry counts per backtrack edge
+pub struct RetryTracker {
+    counts: HashMap<&'static str, usize>,
+    max_retries: usize,
+}
+
+impl RetryTracker {
+    pub fn new(max_retries: usize) -> Self {
+        Self {
+            counts: HashMap::new(),
+            max_retries,
+        }
+    }
+
+    /// returns true if retry is allowed, false if max exceeded.
+    /// increments the counter on each call.
+    pub fn try_retry(&mut self, edge: &'static str) -> bool {
+        let count = self.counts.entry(edge).or_insert(0);
+        *count += 1;
+        *count <= self.max_retries
+    }
+
+    pub fn count(&self, edge: &'static str) -> usize {
+        self.counts.get(edge).copied().unwrap_or(0)
+    }
+}

--- a/edda/edda_forge/template/Cargo.toml
+++ b/edda/edda_forge/template/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "forge-project"
+version = "0.1.0"
+edition = "2024"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/edda/edda_forge/template/benches/bench.rs
+++ b/edda/edda_forge/template/benches/bench.rs
@@ -1,0 +1,8 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn benchmark(_c: &mut Criterion) {
+    // add benchmarks here
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/edda/edda_forge/template/src/lib.rs
+++ b/edda/edda_forge/template/src/lib.rs
@@ -1,0 +1,1 @@
+// generated project — implement your code here

--- a/edda/edda_forge/template/tests/integration.rs
+++ b/edda/edda_forge/template/tests/integration.rs
@@ -1,0 +1,1 @@
+// generated project — write integration tests here


### PR DESCRIPTION
## Summary
- New `edda_forge` crate: state machine orchestrating `claude -p` inside Dagger container
- Generates Rust code from a prompt with automatic backtracking on cargo check/test failures
- Uses `edda_sandbox::DaggerSandbox` for all container operations

## Test plan
- [ ] `cargo check -p edda_forge` passes
- [ ] Manual test: `cargo run -p edda_forge -- --prompt "implement a stack"` produces working project