### PR TITLE
edda_forge: installer + patch filtering

### DIFF
--- a/edda/edda_forge/README.md
+++ b/edda/edda_forge/README.md
@@ -16,15 +16,30 @@ Init → Plan → Work (loop) → Validate → Review → Export → Done
 
 The task list is append-only — failures add new `- [ ] Fix: ...` entries rather than reverting previous work. This gives Claude full context of what was tried.
 
+## Install
+
+```bash
+cargo install --git https://github.com/neondatabase/appdotbuild-agent.git --path edda/edda_forge
+```
+
+Requires [Dagger CLI](https://docs.dagger.io/install/) and a running Docker daemon.
+
+To install the `/forge` slash command for Claude Code:
+
+```bash
+edda-forge --install-claude
+```
+
 ## Usage
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
-cargo run -p edda_forge -- --prompt "implement an LRU cache"
+edda-forge --prompt "implement an LRU cache"
 ```
 
 Options:
-- `--prompt` — task description (required)
+- `--prompt` — task description
+- `--install-claude` — install `/forge` slash command for Claude Code
 - `--config` — path to `forge.toml` (default: auto-discovered)
 - `--source` — source directory to mount in container
 - `--output` — output path (default: `./forge-output`; produces `.patch` by default)
@@ -37,11 +52,11 @@ By default, edda-forge produces a **unified diff** (`.patch` file). A git baseli
 
 ```bash
 # default: patch output
-cargo run -p edda_forge -- --prompt "implement a stack" --output my-stack
+edda-forge --prompt "implement a stack" --output my-stack
 # → writes my-stack.patch
 
 # directory export
-cargo run -p edda_forge -- --prompt "implement a stack" --output ./out --export-dir
+edda-forge --prompt "implement a stack" --output ./out --export-dir
 ```
 
 ## Configuration

--- a/edda/edda_forge/README.md
+++ b/edda/edda_forge/README.md
@@ -70,6 +70,10 @@ RUSTUP_HOME = "/home/forge/.rustup"
 language = "rust"
 source = "."         # codebase to copy into container (relative to config file)
 workdir = "/app"
+exclude = [".git", "target"]  # not mounted into container
+
+[patch]
+exclude = ["tasks.md", "*SUMMARY*.md", "*REPORT*.md", "*venv*/**", "__pycache__/**"]
 
 [steps]
 
@@ -99,6 +103,10 @@ command = "cargo bench 2>&1"
 - `language` — used in AI prompts (e.g. "rust", "python", "typescript")
 - `source` — directory to copy into container (relative to config file)
 - `workdir` — working directory inside container
+- `exclude` — glob patterns excluded from container mount (default: `.git`, `target`, `node_modules`, `.venv`, `__pycache__`)
+
+**`[patch]`** — output patch filtering
+- `exclude` — glob patterns excluded from the output diff (default: `tasks.md`, `*SUMMARY*.md`, `*REPORT*.md`, `*venv*/**`, `__pycache__/**`)
 
 **`[steps]`** — pipeline configuration
 - `validate` — ordered list of validation commands

--- a/edda/edda_forge/forge-command.md
+++ b/edda/edda_forge/forge-command.md
@@ -1,0 +1,254 @@
+Delegate a coding subtask to edda-forge — a sandboxed agent that loops (plan → implement → validate → review) until the code compiles and tests pass, then produces a validated patch. Think of it as delegating to an engineer who returns a tested diff.
+
+Use forge when the subtask is self-contained. Forge runs in an isolated Dagger container, so the user's working tree stays clean until the validated patch is applied.
+
+When multiple independent subtasks are requested, run multiple forge instances concurrently (each with a unique --output path). Apply patches sequentially after all complete.
+
+The subtask is: $ARGUMENTS
+
+## 1. Check forge.toml
+
+Look for `forge.toml` in the project root. If it exists, skip to step 2.
+
+If it doesn't exist, detect the project type and create one.
+
+### Concurrent runs with different validation targets
+
+When running multiple forge instances against different test files or modules, create separate config files (e.g. `forge-auth.toml`, `forge-api.toml`) each with a targeted test command. Pass them via `--config`:
+
+```bash
+edda-forge --config forge-auth.toml --prompt '...' --source . --output ./forge-auth
+edda-forge --config forge-api.toml --prompt '...' --source . --output ./forge-api
+```
+
+The configs should differ only in the test step. Keep a single shared `forge.toml` for solo runs.
+
+### Templates
+
+**Rust** (Cargo.toml present):
+```toml
+[container]
+image = "rust:latest"
+setup = ["apt-get update && apt-get install -y curl sudo git"]
+user = "forge"
+user_setup = """
+useradd -m -s /bin/bash forge \
+  && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+  && cp -r /usr/local/cargo /home/forge/.cargo \
+  && cp -r /usr/local/rustup /home/forge/.rustup \
+  && chown -R forge:forge /home/forge/.cargo /home/forge/.rustup
+"""
+
+[container.env]
+PATH = "/home/forge/.local/bin:/home/forge/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+CARGO_HOME = "/home/forge/.cargo"
+RUSTUP_HOME = "/home/forge/.rustup"
+
+[project]
+language = "rust"
+source = "."
+workdir = "/app"
+
+[steps]
+[[steps.validate]]
+name = "check"
+command = "cargo check 2>&1"
+[[steps.validate]]
+name = "test"
+command = "cargo test 2>&1"
+```
+
+**TypeScript/JavaScript** (package.json present):
+```toml
+[container]
+image = "node:20"
+setup = ["apt-get update && apt-get install -y git sudo"]
+user = "forge"
+user_setup = """
+useradd -m -s /bin/bash forge \
+  && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+"""
+
+[container.env]
+PATH = "/home/forge/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+[project]
+language = "typescript"
+source = "."
+workdir = "/app"
+
+[steps]
+[[steps.validate]]
+name = "install"
+command = "npm install 2>&1"
+[[steps.validate]]
+name = "build"
+command = "npm run build 2>&1"
+[[steps.validate]]
+name = "test"
+command = "npm test 2>&1"
+```
+
+**Python** (pyproject.toml present):
+```toml
+[container]
+image = "python:3.12"
+setup = ["apt-get update && apt-get install -y curl git sudo"]
+user = "forge"
+user_setup = """
+useradd -m -s /bin/bash forge \
+  && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+  && curl -LsSf https://astral.sh/uv/install.sh | su - forge -c bash
+"""
+
+[container.env]
+PATH = "/home/forge/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+[project]
+language = "python"
+source = "."
+workdir = "/app"
+
+[steps]
+[[steps.validate]]
+name = "install"
+command = "uv sync 2>&1"
+[[steps.validate]]
+name = "lint"
+command = "uv run ruff check . 2>&1"
+[[steps.validate]]
+name = "typecheck"
+command = "uv run pyright . 2>&1"
+[[steps.validate]]
+name = "test"
+command = "uv run pytest 2>&1"
+```
+
+**Python + Rust / maturin** (both pyproject.toml and Cargo.toml, with `[tool.maturin]` or `maturin` in build-system):
+```toml
+[container]
+image = "python:3.12"
+setup = [
+    "apt-get update && apt-get install -y curl git sudo build-essential",
+]
+user = "forge"
+user_setup = """
+useradd -m -s /bin/bash forge \
+  && echo 'forge ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+  && su - forge -c 'curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y' \
+  && su - forge -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+"""
+
+[container.env]
+PATH = "/home/forge/.local/bin:/home/forge/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+CARGO_HOME = "/home/forge/.cargo"
+RUSTUP_HOME = "/home/forge/.rustup"
+
+[project]
+language = "python"
+source = "."
+workdir = "/app"
+
+[steps]
+[[steps.validate]]
+name = "sync"
+command = "uv sync 2>&1"
+[[steps.validate]]
+name = "build-rust"
+command = "uv run maturin develop 2>&1"
+[[steps.validate]]
+name = "test"
+command = "uv run pytest 2>&1"
+```
+
+Note: Rust and uv are installed as the forge user (via `su - forge -c`), not as root. This avoids permission errors when `maturin` or `cargo` run later.
+
+Show the generated forge.toml to the user and ask for confirmation before writing it.
+
+## 2. Run forge
+
+Always specify a unique output path to avoid conflicts between concurrent runs. Derive it from the subtask (e.g. slugified keyword):
+
+```bash
+edda-forge --prompt '<the subtask>' --source . --output ./forge-<slug> --max-retries 3
+```
+
+ANTHROPIC_API_KEY must be set.
+
+If running multiple forge instances concurrently, launch each in the background and wait for all to complete.
+
+### Prompt quality matters
+
+For simple tasks ("add a logging middleware"), a short prompt is fine. For algorithmic or precision-sensitive tasks, **include the exact contract in the prompt** — don't just say "study the test file." Spell out:
+- The exact function signatures and return types
+- Key invariants and assertions the code must satisfy
+- Edge cases (zero weights, NaN handling, empty inputs)
+
+A vague prompt that fails review 3 times wastes more time than a detailed prompt that succeeds on the first try.
+
+### Choosing `--max-retries`
+
+- Simple tasks (wrapping existing APIs, straightforward CRUD): `--max-retries 3`
+- Complex tasks (algorithms, precision-sensitive, many edge cases): `--max-retries 5`
+
+## 3. Apply and clean up
+
+On success (exit 0), apply each patch sequentially:
+```bash
+git apply forge-<slug>.patch && rm forge-<slug>.patch
+```
+
+### Handling patch conflicts across concurrent runs
+
+When multiple forge instances modify overlapping files (e.g. `__init__.py`, `conftest.py`), later patches will fail to apply. This is the most common issue with concurrent forge runs.
+
+Strategies, in order of preference:
+
+1. **Exclude conflicting files, merge manually.** Apply the patch excluding known conflicts, then hand-merge the conflicting files:
+   ```bash
+   git apply --exclude='path/to/conflict.py' forge-<slug>.patch
+   ```
+   Then read the excluded hunks from the patch and apply the relevant parts via Edit.
+
+2. **Commit between patches and use 3-way merge.** After applying each patch, commit it. Then apply the next with `--3way`:
+   ```bash
+   git apply forge-first.patch && git add -A && git commit -m "apply first"
+   git apply --3way forge-second.patch
+   ```
+
+3. **Apply smallest/most-independent patches first.** Order by: utility modules → core logic → integration/glue code. The glue patches (which touch shared files like `__init__.py`) should go last.
+
+### Forge produced junk files
+
+Forge sometimes creates summary/documentation files (`SUMMARY.md`, `IMPLEMENTATION.md`) or extra test files at the project root. Exclude these when applying:
+```bash
+git apply --exclude='*.md' --exclude='test_*.py' forge-<slug>.patch
+```
+Or selectively include only the relevant directories:
+```bash
+git apply --include='src/*' --include='tests/*' forge-<slug>.patch
+```
+
+On forge failure: show the error and suggest the user refine the prompt or adjust forge.toml validation steps.
+
+## 4. Verify
+
+Run the **actual target tests** locally after applying patches — not just a build check. The container environment may differ from local (different random seeds, dependency versions, etc.):
+
+```bash
+# Python
+uv run pytest tests/ -x -q
+
+# Rust
+cargo test
+
+# TypeScript
+npm test
+```
+
+Show `git diff --stat` so the user can review what changed.
+
+Clean up any leftover forge config and patch files:
+```bash
+rm -f forge-*.toml forge-*.patch
+```

--- a/edda/edda_forge/forge.toml
+++ b/edda/edda_forge/forge.toml
@@ -23,6 +23,9 @@ source = "."
 workdir = "/app"
 exclude = [".git", "target"]
 
+[patch]
+exclude = ["tasks.md", "*SUMMARY*.md", "*REPORT*.md", "*venv*/**", "__pycache__/**"]
+
 [steps]
 
 [[steps.validate]]

--- a/edda/edda_forge/forge.toml
+++ b/edda/edda_forge/forge.toml
@@ -21,6 +21,7 @@ RUSTUP_HOME = "/home/forge/.rustup"
 language = "rust"
 source = "."
 workdir = "/app"
+exclude = [".git", "target"]
 
 [steps]
 

--- a/edda/edda_forge/src/config.rs
+++ b/edda/edda_forge/src/config.rs
@@ -8,6 +8,34 @@ pub struct ForgeConfig {
     pub container: ContainerConfig,
     pub project: ProjectConfig,
     pub steps: StepsConfig,
+    #[serde(default)]
+    pub patch: PatchConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PatchConfig {
+    /// glob patterns to exclude from the output patch (git pathspec exclude)
+    #[serde(default = "default_patch_excludes")]
+    pub exclude: Vec<String>,
+}
+
+impl Default for PatchConfig {
+    fn default() -> Self {
+        Self {
+            exclude: default_patch_excludes(),
+        }
+    }
+}
+
+fn default_patch_excludes() -> Vec<String> {
+    vec![
+        "tasks.md".into(),
+        "*SUMMARY*.md".into(),
+        "*REPORT*.md".into(),
+        "*_venv*".into(),
+        "*venv*/**".into(),
+        "__pycache__/**".into(),
+    ]
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -77,6 +105,7 @@ impl ForgeConfig {
                 workdir: "/app".into(),
                 exclude: default_excludes(),
             },
+            patch: PatchConfig::default(),
             steps: StepsConfig {
                 validate: vec![
                     ValidateStep {
@@ -124,6 +153,17 @@ fn default_excludes() -> Vec<String> {
         ".venv".into(),
         "__pycache__".into(),
     ]
+}
+
+impl PatchConfig {
+    /// build git pathspec exclusion args: `-- . ':!pat1' ':!pat2' ...`
+    pub fn git_diff_pathspec(&self) -> String {
+        let mut spec = String::from("-- .");
+        for pat in &self.exclude {
+            spec.push_str(&format!(" ':!{pat}'"));
+        }
+        spec
+    }
 }
 
 /// resolve source path relative to the config file's directory

--- a/edda/edda_forge/src/config.rs
+++ b/edda/edda_forge/src/config.rs
@@ -25,6 +25,9 @@ pub struct ProjectConfig {
     pub language: String,
     pub source: String,
     pub workdir: String,
+    /// glob patterns to exclude when mounting source into container
+    #[serde(default)]
+    pub exclude: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -72,6 +75,7 @@ impl ForgeConfig {
                 language: "rust".into(),
                 source: ".".into(),
                 workdir: "/app".into(),
+                exclude: default_excludes(),
             },
             steps: StepsConfig {
                 validate: vec![
@@ -110,6 +114,16 @@ impl ForgeConfig {
         }
         Ok(())
     }
+}
+
+fn default_excludes() -> Vec<String> {
+    vec![
+        ".git".into(),
+        "target".into(),
+        "node_modules".into(),
+        ".venv".into(),
+        "__pycache__".into(),
+    ]
 }
 
 /// resolve source path relative to the config file's directory

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -57,8 +57,12 @@ EXAMPLES:
 )]
 struct Cli {
     /// Natural language task description for code generation
+    #[arg(long, required_unless_present = "install_claude")]
+    prompt: Option<String>,
+
+    /// Install the /forge slash command for Claude Code (~/.claude/commands/forge.md)
     #[arg(long)]
-    prompt: String,
+    install_claude: bool,
 
     /// Path to forge.toml config file
     ///
@@ -100,6 +104,12 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+
+    if cli.install_claude {
+        return install_claude_command();
+    }
+
+    let prompt = cli.prompt.expect("--prompt is required");
 
     let api_key = std::env::var("ANTHROPIC_API_KEY")
         .map_err(|_| eyre::eyre!("ANTHROPIC_API_KEY not set"))?;
@@ -156,7 +166,7 @@ async fn main() -> Result<()> {
     info!(source = %source_path.display(), "resolved source path");
 
     let output = cli.output.clone();
-    let prompt = cli.prompt.clone();
+    let prompt = prompt.clone();
     let max_retries = cli.max_retries;
     let export_dir = cli.export_dir;
 
@@ -445,6 +455,17 @@ async fn step(
 
         State::Done | State::Failed { .. } => state,
     }
+}
+
+fn install_claude_command() -> Result<()> {
+    const COMMAND: &str = include_str!("../forge-command.md");
+    let home = std::env::var("HOME").map_err(|_| eyre::eyre!("HOME not set"))?;
+    let dir = PathBuf::from(home).join(".claude/commands");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("forge.md");
+    std::fs::write(&path, COMMAND)?;
+    println!("installed /forge command → {}", path.display());
+    Ok(())
 }
 
 fn truncate_string(s: &str, max: usize) -> String {

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -212,7 +212,10 @@ async fn main() -> Result<()> {
                     };
                     info!(patch = %patch_path.display(), "generating patch");
                     let diff_result = sandbox
-                        .exec("git add -A && git diff --cached -- . ':!tasks.md'")
+                        .exec(&format!(
+                            "git add -A && git diff --cached {}",
+                            forge_config.patch.git_diff_pathspec()
+                        ))
                         .await?;
                     if diff_result.exit_code != 0 {
                         bail!("git diff failed: {}", diff_result.stderr);

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -111,6 +111,13 @@ async fn main() -> Result<()> {
 
     let prompt = cli.prompt.expect("--prompt is required");
 
+    if let Ok(home) = std::env::var("HOME") {
+        let cmd_path = PathBuf::from(home).join(".claude/commands/forge.md");
+        if !cmd_path.exists() {
+            eprintln!("hint: run `edda-forge --install-claude` to install the /forge slash command for Claude Code");
+        }
+    }
+
     let api_key = std::env::var("ANTHROPIC_API_KEY")
         .map_err(|_| eyre::eyre!("ANTHROPIC_API_KEY not set"))?;
 

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -76,12 +76,12 @@ pub fn parse_task_stats(task_list: &str) -> TaskStats {
     let mut pending_tasks = Vec::new();
     for line in task_list.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]") {
+        if let Some(rest) = trimmed.strip_prefix("- [x]").or_else(|| trimmed.strip_prefix("- [X]")) {
             done += 1;
-            done_tasks.push(trimmed[5..].trim().to_string());
-        } else if trimmed.starts_with("- [ ]") {
+            done_tasks.push(rest.trim().to_string());
+        } else if let Some(rest) = trimmed.strip_prefix("- [ ]") {
             pending += 1;
-            pending_tasks.push(trimmed[5..].trim().to_string());
+            pending_tasks.push(rest.trim().to_string());
         }
     }
     TaskStats { done, pending, done_tasks, pending_tasks }

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -97,7 +97,10 @@ pub async fn work(sandbox: &mut impl Sandbox, language: &str) -> Result<()> {
          Work on the unchecked tasks (- [ ]). For each task you complete, \
          update /app/tasks.md to mark it as done (- [x]). \
          You may complete multiple tasks in one go. \
-         Focus on correctness."
+         Focus on correctness.\n\n\
+         IMPORTANT: Do NOT create summary/report files (SUMMARY.md, REPORT.md, etc.), \
+         scratch test scripts at the project root, or virtual environments. \
+         Only create files that are part of the project deliverable."
     );
 
     info!("working on unchecked tasks");


### PR DESCRIPTION
## Summary
- Add `project.exclude` config for skipping large dirs (.git, target) from container mount
- Add `[patch] exclude` config for filtering junk files from output diffs
- Add `--install-claude` flag to install the `/forge` slash command for Claude Code
- Hint about `--install-claude` on first run when command not found

## Test plan
- [x] `cargo check -p edda_forge`
- [x] `edda-forge --install-claude` installs to `~/.claude/commands/forge.md`
- [ ] Run forge on a project, verify patch excludes configured patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)