### PR TITLE
Fix Dagger query depth limit crash in long forge runs

### DIFF
--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -251,7 +251,7 @@ async fn main() -> Result<()> {
         Ok(())
     })
     .await
-    .map_err(|e| eyre::eyre!("dagger error: {e}"))?;
+    .map_err(|e| eyre::eyre!("dagger error: {e:#}"))?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Dagger SDK builds a nested GraphQL query for every chained container operation (`exec`, `write_file`, etc.). After ~120 operations the query exceeds engine limits and fails with a generic "an error occurred from the dagger context call" error.
- All 3 concurrent forge instances hit this at the Export stage — the container worked fine during Plan/Work/Validate/Review, but the accumulated chain depth exceeded the limit by the time `git diff` ran.
- Fix: track operations and auto-sync (materialize container + reload from ID) every 80 ops, resetting the query chain to depth 1.
- Also fix error reporting in `edda_forge` to print the full error chain (`{e:#}` instead of `{e}`).

## Test plan

- [x] Reproduced with toy example: 200 chained execs fails at ~120 without fix, succeeds with auto-sync
- [ ] Re-run the 3 concurrent forge instances that originally failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)