### PR TITLE
forge: assorted improvements

### DIFF
--- a/edda/edda_forge/src/config.rs
+++ b/edda/edda_forge/src/config.rs
@@ -35,6 +35,8 @@ fn default_patch_excludes() -> Vec<String> {
         "*_venv*".into(),
         "*venv*/**".into(),
         "__pycache__/**".into(),
+        "target/**".into(),
+        "node_modules/**".into(),
     ]
 }
 
@@ -156,11 +158,11 @@ fn default_excludes() -> Vec<String> {
 }
 
 impl PatchConfig {
-    /// build git pathspec exclusion args: `-- . ':!pat1' ':!pat2' ...`
+    /// build git pathspec exclusion args: `-- . ':(exclude)pat1' ':(exclude)pat2' ...`
     pub fn git_diff_pathspec(&self) -> String {
         let mut spec = String::from("-- .");
         for pat in &self.exclude {
-            spec.push_str(&format!(" ':!{pat}'"));
+            spec.push_str(&format!(" ':(exclude){pat}'"));
         }
         spec
     }

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -446,7 +446,7 @@ async fn step(
         }
 
         State::Review => {
-            match runner::review(sandbox, language).await {
+            match runner::review(sandbox, language, &config.patch.git_diff_pathspec()).await {
                 Ok(runner::ReviewVerdict::Approved) => {
                     info!("review approved");
                     State::Export

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -10,6 +10,7 @@ use edda_sandbox::dagger::{ConnectOpts, Logger};
 use eyre::{Result, bail};
 use state::State;
 use std::path::PathBuf;
+use std::time::Instant;
 use tracing::{error, info, warn};
 
 #[derive(Parser)]
@@ -173,7 +174,6 @@ async fn main() -> Result<()> {
     info!(source = %source_path.display(), "resolved source path");
 
     let output = cli.output.clone();
-    let prompt = prompt.clone();
     let max_retries = cli.max_retries;
     let export_dir = cli.export_dir;
 
@@ -205,13 +205,30 @@ async fn main() -> Result<()> {
         let _ = sandbox.exec("rm -f tasks.md").await;
 
         let mut state = State::Init { prompt };
-        let mut retries = 0usize;
+        let mut validate_retries = 0usize;
+        let mut review_retries = 0usize;
+        let run_start = Instant::now();
 
         while !state.is_terminal() {
             let old = format!("{state}");
-            state = step(state, &mut sandbox, &mut retries, max_retries, &forge_config).await;
-            info!(from = %old, to = %state, "state transition");
+            let step_start = Instant::now();
+            state = step(
+                state,
+                &mut sandbox,
+                &mut validate_retries,
+                &mut review_retries,
+                max_retries,
+                &forge_config,
+            )
+            .await;
+            info!(
+                from = %old,
+                to = %state,
+                elapsed_secs = step_start.elapsed().as_secs(),
+                "state transition"
+            );
         }
+        info!(total_secs = run_start.elapsed().as_secs(), "forge finished");
 
         // sync container before export to flatten the query chain
         sandbox.sync().await?;
@@ -221,7 +238,7 @@ async fn main() -> Result<()> {
                 if export_dir {
                     info!(output = %output.display(), "exporting project directory");
                     sandbox
-                        .export_directory("/app", &output.to_string_lossy())
+                        .export_directory(workdir, &output.to_string_lossy())
                         .await?;
                     info!("directory export complete");
                 } else {
@@ -231,11 +248,20 @@ async fn main() -> Result<()> {
                         output.with_extension("patch")
                     };
                     info!(patch = %patch_path.display(), "generating patch");
+                    // stage everything and discover binary files
+                    let numstat = sandbox
+                        .exec("git add -A && git diff --cached --numstat")
+                        .await?;
+                    let mut pathspec = forge_config.patch.git_diff_pathspec();
+                    for line in numstat.stdout.lines() {
+                        // binary files show as "-\t-\tpath"
+                        let parts: Vec<&str> = line.splitn(3, '\t').collect();
+                        if parts.len() == 3 && parts[0] == "-" && parts[1] == "-" {
+                            pathspec.push_str(&format!(" ':(exclude){}'", parts[2]));
+                        }
+                    }
                     let diff_result = sandbox
-                        .exec(&format!(
-                            "git add -A && git diff --cached {}",
-                            forge_config.patch.git_diff_pathspec()
-                        ))
+                        .exec(&format!("git diff --cached {pathspec}"))
                         .await?;
                     if diff_result.exit_code != 0 {
                         bail!("git diff failed: {}", diff_result.stderr);
@@ -270,7 +296,8 @@ async fn main() -> Result<()> {
 async fn step(
     state: State,
     sandbox: &mut impl Sandbox,
-    retries: &mut usize,
+    validate_retries: &mut usize,
+    review_retries: &mut usize,
     max_retries: usize,
     config: &ForgeConfig,
 ) -> State {
@@ -381,8 +408,8 @@ async fn step(
                 }
                 Ok(result) => {
                     let error_output = format!("{}\n{}", result.stdout, result.stderr);
-                    *retries += 1;
-                    if *retries > max_retries {
+                    *validate_retries += 1;
+                    if *validate_retries > max_retries {
                         return State::Failed {
                             reason: format!(
                                 "validation step '{}' failed after {} retries: {}",
@@ -395,14 +422,14 @@ async fn step(
 
                     warn!(
                         step = %step.name,
-                        attempt = *retries,
+                        attempt = *validate_retries,
                         "validation failed, appending fix task"
                     );
 
                     let description = format!(
                         "Fix: `{}` failed (attempt {}) — {}",
                         step.name,
-                        *retries,
+                        *validate_retries,
                         truncate_string(&error_output, 300)
                     );
                     match runner::append_task(sandbox, &description).await {
@@ -425,8 +452,8 @@ async fn step(
                     State::Export
                 }
                 Ok(runner::ReviewVerdict::Rejected { feedback }) => {
-                    *retries += 1;
-                    if *retries > max_retries {
+                    *review_retries += 1;
+                    if *review_retries > max_retries {
                         return State::Failed {
                             reason: format!(
                                 "review rejected after {} retries: {}",
@@ -437,14 +464,14 @@ async fn step(
                     }
 
                     warn!(
-                        attempt = *retries,
+                        attempt = *review_retries,
                         feedback = %feedback,
                         "review rejected, appending fix task"
                     );
 
                     let description = format!(
                         "Fix: review rejected (attempt {}) — {}",
-                        *retries, feedback
+                        *review_retries, feedback
                     );
                     match runner::append_task(sandbox, &description).await {
                         Ok(()) => State::Work,
@@ -454,13 +481,13 @@ async fn step(
                     }
                 }
                 Ok(runner::ReviewVerdict::InvalidFormat) => {
-                    *retries += 1;
-                    if *retries > max_retries {
+                    *review_retries += 1;
+                    if *review_retries > max_retries {
                         return State::Failed {
                             reason: "review returned invalid format after max retries".into(),
                         };
                     }
-                    warn!(attempt = *retries, "review returned invalid format, retrying");
+                    warn!(attempt = *review_retries, "review returned invalid format, retrying");
                     State::Review
                 }
                 Err(e) => State::Failed {
@@ -487,9 +514,8 @@ fn install_claude_command() -> Result<()> {
 }
 
 fn truncate_string(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max])
+    match s.get(..max) {
+        Some(prefix) => format!("{prefix}..."),
+        None => s.to_string(),
     }
 }

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -139,7 +139,7 @@ pub enum ReviewVerdict {
 }
 
 /// ask Claude to review the diff
-pub async fn review(sandbox: &mut impl Sandbox, language: &str) -> Result<ReviewVerdict> {
+pub async fn review(sandbox: &mut impl Sandbox, language: &str, diff_pathspec: &str) -> Result<ReviewVerdict> {
     let task_list = match read_tasks(sandbox).await {
         Ok(tasks) => tasks,
         Err(e) => {
@@ -155,7 +155,7 @@ pub async fn review(sandbox: &mut impl Sandbox, language: &str) -> Result<Review
 
     let instruction = format!(
         "You are a {language} code reviewer working in /app. \
-         Review the staged changes (run `git diff --cached` to see the diff).\n\n\
+         Review the staged changes (run `git diff --cached {diff_pathspec}` to see the diff).\n\n\
          Task list:\n{task_list}\n\n\
          Check for correctness and bugs only. Do NOT write or modify any files.\n\n\
          Respond ONLY with one of:\n\

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -27,7 +27,10 @@ fn check_exec(result: &ExecResult, step: &str) -> Result<()> {
 }
 
 fn truncate(s: &str, max: usize) -> &str {
-    if s.len() <= max { s } else { &s[..max] }
+    match s.get(..max) {
+        Some(prefix) => prefix,
+        None => s,
+    }
 }
 
 /// ask Claude to decompose the prompt into a checkbox task list (tasks.md)
@@ -137,9 +140,18 @@ pub enum ReviewVerdict {
 
 /// ask Claude to review the diff
 pub async fn review(sandbox: &mut impl Sandbox, language: &str) -> Result<ReviewVerdict> {
-    let task_list = read_tasks(sandbox).await.unwrap_or_default();
+    let task_list = match read_tasks(sandbox).await {
+        Ok(tasks) => tasks,
+        Err(e) => {
+            warn!("could not read tasks.md for review context: {e}");
+            String::new()
+        }
+    };
     // stage all changes so Claude can inspect via `git diff --cached`
-    let _ = sandbox.exec("git add -A").await;
+    let stage = sandbox.exec("git add -A").await?;
+    if stage.exit_code != 0 {
+        bail!("git add -A failed: {}", stage.stderr);
+    }
 
     let instruction = format!(
         "You are a {language} code reviewer working in /app. \


### PR DESCRIPTION
## Summary
- Separate retry counters for validation vs review (previously shared, so 2 validation failures + 1 review rejection = exhausted)
- Fix UTF-8 panic in truncation helpers (`&s[..max]` → `s.get(..max)`)
- Warn instead of silently swallowing missing tasks.md in review
- Bail on `git add -A` failure before review instead of ignoring
- Add elapsed time logging (per-step and total)
- Use `workdir` variable for export instead of hardcoded `/app`
- Remove redundant `prompt.clone()`
- Fix git pathspec syntax to `:(exclude)` form
- Exclude `target/` and `node_modules/` from patches by default
- Auto-exclude binary files from patch output

## Test plan
- [x] Run forge on a Rust project, verify timing appears in logs
- [x] Trigger validation failure, confirm retry counter is independent from review
- [x] Verify patch excludes binary files

🤖 Generated with [Claude Code](https://claude.com/claude-code)