### PR TITLE
forge: add opencode backend support

### DIFF
--- a/edda/Cargo.lock
+++ b/edda/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "edda_sandbox",
  "eyre",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
  "tracing",

--- a/edda/edda_forge/Cargo.toml
+++ b/edda/edda_forge/Cargo.toml
@@ -17,3 +17,6 @@ eyre = "0.6"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 dagger-sdk = "0.18.16"
+
+[dev-dependencies]
+serde_json = "1"


### PR DESCRIPTION
## Summary
- Add multi-agent backend support to edda-forge (Claude Code + OpenCode)
- Agent configured via `agent` field in forge.toml using `backend:model` syntax (e.g. `agent = "opencode:opencode/kimi-k2.5-free"`, `agent = "claude:claude-sonnet-4-5-20250929"`)
- Default remains `claude` with no model needed
- For OpenCode: mounts `~/.local/share/opencode/auth.json` and `~/.config/opencode/` into container, writes `{"permission":"allow"}` for non-interactive use
- Model flag (`--model`) works for both backends
- README updated (by Kimi K2.5 via forge itself)
- 7 unit tests for AgentConfig deserialization

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (7 new tests)
- [x] Dogfooded: ran `edda-forge` with `opencode:opencode/kimi-k2.5-free` backend to update its own README — completed successfully (Plan → Work → Validate → Review APPROVED → Export in 113s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)