### PR TITLE
forge: trajectory logging, mounts, install caching

### DIFF
--- a/edda/edda_forge/Cargo.toml
+++ b/edda/edda_forge/Cargo.toml
@@ -15,8 +15,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }
 eyre = "0.6"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
 dagger-sdk = "0.18.16"
-
-[dev-dependencies]
-serde_json = "1"

--- a/edda/edda_forge/src/config.rs
+++ b/edda/edda_forge/src/config.rs
@@ -58,6 +58,17 @@ pub struct ForgeConfig {
     pub steps: StepsConfig,
     #[serde(default)]
     pub patch: PatchConfig,
+    /// extra host paths to mount into the container
+    #[serde(default)]
+    pub mounts: Vec<MountConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MountConfig {
+    /// host path (~ is expanded to $HOME)
+    pub host: String,
+    /// absolute path inside the container
+    pub container: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -158,6 +169,7 @@ impl ForgeConfig {
                 exclude: default_excludes(),
             },
             patch: PatchConfig::default(),
+            mounts: vec![],
             steps: StepsConfig {
                 validate: vec![
                     ValidateStep {
@@ -193,6 +205,17 @@ impl ForgeConfig {
         if self.steps.validate.is_empty() {
             bail!("steps.validate must have at least one step");
         }
+        for m in &self.mounts {
+            if m.host.is_empty() {
+                bail!("mount host path must not be empty");
+            }
+            if !m.container.starts_with('/') {
+                bail!(
+                    "mount container path must be absolute, got: '{}'",
+                    m.container
+                );
+            }
+        }
         Ok(())
     }
 }
@@ -215,6 +238,23 @@ impl PatchConfig {
             spec.push_str(&format!(" ':(exclude){pat}'"));
         }
         spec
+    }
+}
+
+impl MountConfig {
+    /// expand ~ to $HOME in the host path
+    pub fn resolve_host_path(&self) -> Result<PathBuf> {
+        let path = if self.host.starts_with('~') {
+            let home = std::env::var("HOME")
+                .map_err(|_| eyre::eyre!("HOME not set, cannot expand ~ in mount path"))?;
+            PathBuf::from(self.host.replacen('~', &home, 1))
+        } else {
+            PathBuf::from(&self.host)
+        };
+        if !path.exists() {
+            bail!("mount host path does not exist: {}", path.display());
+        }
+        Ok(path)
     }
 }
 

--- a/edda/edda_forge/src/config.rs
+++ b/edda/edda_forge/src/config.rs
@@ -242,14 +242,14 @@ impl PatchConfig {
 }
 
 impl MountConfig {
-    /// expand ~ to $HOME in the host path
-    pub fn resolve_host_path(&self) -> Result<PathBuf> {
+    /// resolve host path relative to config_dir, with ~ expansion
+    pub fn resolve_host_path(&self, config_dir: &Path) -> Result<PathBuf> {
         let path = if self.host.starts_with('~') {
             let home = std::env::var("HOME")
                 .map_err(|_| eyre::eyre!("HOME not set, cannot expand ~ in mount path"))?;
             PathBuf::from(self.host.replacen('~', &home, 1))
         } else {
-            PathBuf::from(&self.host)
+            config_dir.join(&self.host)
         };
         if !path.exists() {
             bail!("mount host path does not exist: {}", path.display());

--- a/edda/edda_forge/src/container.rs
+++ b/edda/edda_forge/src/container.rs
@@ -20,6 +20,7 @@ pub async fn setup_container(
     auth: &AgentAuth,
     config: &ForgeConfig,
     source_path: &Path,
+    config_dir: &Path,
 ) -> Result<DaggerSandbox> {
     let exclude_refs: Vec<&str> = config.project.exclude.iter().map(|s| s.as_str()).collect();
     let source_dir = if exclude_refs.is_empty() {
@@ -59,7 +60,7 @@ pub async fn setup_container(
 
     // mount custom paths before switching to user (needs root for chown)
     for mount in &config.mounts {
-        let host_path = mount.resolve_host_path()?;
+        let host_path = mount.resolve_host_path(config_dir)?;
         let target = &mount.container;
         if host_path.is_file() {
             let host_file = client.host().file(host_path.to_string_lossy().to_string());
@@ -70,10 +71,8 @@ pub async fn setup_container(
                 .directory(host_path.to_string_lossy().to_string());
             ctr = ctr.with_directory(target, host_dir);
         }
+        ctr = ctr.with_exec(sh(&format!("chown -R {user}:{user} {target}")));
         tracing::info!(host = %host_path.display(), container = %target, "mounted custom path");
-    }
-    if !config.mounts.is_empty() {
-        ctr = ctr.with_exec(sh(&format!("chown -R {user}:{user} {home}")));
     }
 
     // mount opencode auth/config before switching to user (needs root for chown)
@@ -88,7 +87,6 @@ pub async fn setup_container(
             let host_dir = client.host().directory(config_dir);
             ctr = ctr.with_directory(&target, host_dir);
         }
-        // chown the whole user home to fix ownership of mounted files
         ctr = ctr.with_exec(sh(&format!("chown -R {user}:{user} {home}")));
     }
 

--- a/edda/edda_forge/src/container.rs
+++ b/edda/edda_forge/src/container.rs
@@ -57,6 +57,25 @@ pub async fn setup_container(
 
     let home = format!("/home/{user}");
 
+    // mount custom paths before switching to user (needs root for chown)
+    for mount in &config.mounts {
+        let host_path = mount.resolve_host_path()?;
+        let target = &mount.container;
+        if host_path.is_file() {
+            let host_file = client.host().file(host_path.to_string_lossy().to_string());
+            ctr = ctr.with_file(target, host_file);
+        } else {
+            let host_dir = client
+                .host()
+                .directory(host_path.to_string_lossy().to_string());
+            ctr = ctr.with_directory(target, host_dir);
+        }
+        tracing::info!(host = %host_path.display(), container = %target, "mounted custom path");
+    }
+    if !config.mounts.is_empty() {
+        ctr = ctr.with_exec(sh(&format!("chown -R {user}:{user} {home}")));
+    }
+
     // mount opencode auth/config before switching to user (needs root for chown)
     if matches!(&config.agent.backend, AgentBackend::OpenCode) {
         if let Some(auth_file) = &auth.opencode_auth_file {
@@ -89,7 +108,20 @@ pub async fn setup_container(
     // install agent CLI and configure
     match &config.agent.backend {
         AgentBackend::Claude => {
-            ctr = ctr.with_exec(sh("curl -fsSL https://claude.ai/install.sh | bash"));
+            let install_cmd = format!(
+                "set -eu; \
+                 mkdir -p {home}/.local/bin {home}/.local/share/claude/versions {home}/.claude; \
+                 lock_file={home}/.claude/install.lock; \
+                 if command -v flock >/dev/null 2>&1; then exec 9>\"$lock_file\"; flock 9; fi; \
+                 latest=$(ls -1 {home}/.local/share/claude/versions 2>/dev/null | sort -V | tail -n 1 || true); \
+                 if [ -n \"$latest\" ] && [ -x {home}/.local/share/claude/versions/$latest ]; then \
+                   ln -sf {home}/.local/share/claude/versions/$latest {home}/.local/bin/claude; \
+                   claude --version; \
+                 else \
+                   curl -fsSL https://claude.ai/install.sh | bash; \
+                 fi"
+            );
+            ctr = ctr.with_exec(sh(&install_cmd));
         }
         AgentBackend::OpenCode => {
             ctr = ctr.with_exec(sh(

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -203,7 +203,9 @@ async fn main() -> Result<()> {
     let max_retries = cli.max_retries;
     let export_dir = cli.export_dir;
 
-    let opts = ConnectOpts::new(Logger::Tracing, Some(600));
+    // Claude installer + first cold container materialization can exceed the
+    // default timeout, especially when multiple forge runs execute in parallel.
+    let opts = ConnectOpts::new(Logger::Tracing, Some(3600));
     opts.connect(move |client| async move {
         let mut sandbox =
             container::setup_container(client, &agent_auth, &forge_config, &source_path).await?;

--- a/edda/edda_forge/src/main.rs
+++ b/edda/edda_forge/src/main.rs
@@ -208,7 +208,7 @@ async fn main() -> Result<()> {
     let opts = ConnectOpts::new(Logger::Tracing, Some(3600));
     opts.connect(move |client| async move {
         let mut sandbox =
-            container::setup_container(client, &agent_auth, &forge_config, &source_path).await?;
+            container::setup_container(client, &agent_auth, &forge_config, &source_path, &config_dir).await?;
 
         // create git baseline for diff output
         info!("creating git baseline commit");

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -120,7 +120,10 @@ fn log_trajectory(stdout: &str, step: &str) {
         }
         let parsed: TrajectoryLine = match serde_json::from_str(line) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(e) => {
+                warn!(step, error = %e, line = %truncate_tail(line, 200), "failed to parse trajectory line");
+                continue;
+            }
         };
         match parsed.msg_type.as_str() {
             "assistant" => {

--- a/edda/edda_forge/src/runner.rs
+++ b/edda/edda_forge/src/runner.rs
@@ -1,9 +1,10 @@
 use crate::config::{AgentBackend, AgentConfig, ValidateStep};
 use edda_sandbox::{ExecResult, Sandbox};
 use eyre::{Result, bail};
+use serde::Deserialize;
 use tracing::{debug, info, warn};
 
-fn agent_cmd(agent: &AgentConfig, prompt: &str) -> String {
+fn agent_cmd(agent: &AgentConfig, prompt: &str, trajectory: bool) -> String {
     let escaped = prompt.replace('\'', "'\\''");
     let model_flag = agent
         .model
@@ -12,7 +13,12 @@ fn agent_cmd(agent: &AgentConfig, prompt: &str) -> String {
         .unwrap_or_default();
     match &agent.backend {
         AgentBackend::Claude => {
-            format!("claude -p '{escaped}'{model_flag} --dangerously-skip-permissions")
+            let traj_flags = if trajectory {
+                " --output-format stream-json --verbose"
+            } else {
+                ""
+            };
+            format!("claude -p '{escaped}'{model_flag} --dangerously-skip-permissions{traj_flags}")
         }
         AgentBackend::OpenCode => {
             format!("opencode run{model_flag} '{escaped}'")
@@ -20,27 +26,139 @@ fn agent_cmd(agent: &AgentConfig, prompt: &str) -> String {
     }
 }
 
+fn log_exec(result: &ExecResult, step: &str) {
+    debug!(
+        step,
+        exit_code = result.exit_code,
+        stdout_len = result.stdout.len(),
+        stderr_len = result.stderr.len(),
+        stdout_tail = %truncate_tail(&result.stdout, 500),
+        stderr_tail = %truncate_tail(&result.stderr, 500),
+        "exec output"
+    );
+}
+
 fn check_exec(result: &ExecResult, step: &str) -> Result<()> {
     if result.exit_code != 0 {
         warn!(
             step,
             exit_code = result.exit_code,
-            stderr_len = result.stderr.len(),
+            stdout = %result.stdout,
+            stderr = %result.stderr,
             "step failed"
         );
         bail!(
-            "{step} failed (exit {}): {}",
+            "{step} failed (exit {}):\nstdout: {}\nstderr: {}",
             result.exit_code,
-            truncate(&result.stderr, 2000)
+            result.stdout,
+            result.stderr
         );
     }
+    log_exec(result, step);
     Ok(())
 }
 
-fn truncate(s: &str, max: usize) -> &str {
-    match s.get(..max) {
-        Some(prefix) => prefix,
-        None => s,
+fn truncate_tail(s: &str, max: usize) -> &str {
+    let len = s.len();
+    if len <= max {
+        return s;
+    }
+    let mut start = len - max;
+    while !s.is_char_boundary(start) {
+        start += 1;
+    }
+    &s[start..]
+}
+
+// --- stream-json trajectory parsing ---
+
+#[derive(Deserialize)]
+struct TrajectoryLine {
+    #[serde(rename = "type")]
+    msg_type: String,
+    #[serde(default)]
+    message: Option<AssistantMessage>,
+    // result fields
+    #[serde(default)]
+    num_turns: Option<u32>,
+    #[serde(default)]
+    total_cost_usd: Option<f64>,
+    #[serde(default)]
+    is_error: Option<bool>,
+    // tool result content
+    #[serde(default)]
+    content: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct AssistantMessage {
+    #[serde(default)]
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        name: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+    #[serde(other)]
+    Other,
+}
+
+/// log each line of a stream-json trajectory
+fn log_trajectory(stdout: &str, step: &str) {
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let parsed: TrajectoryLine = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        match parsed.msg_type.as_str() {
+            "assistant" => {
+                if let Some(msg) = &parsed.message {
+                    for block in &msg.content {
+                        match block {
+                            ContentBlock::Text { text } => {
+                                info!(step, text = %truncate_tail(text, 200), "agent text");
+                            }
+                            ContentBlock::ToolUse { name, input } => {
+                                let args = serde_json::to_string(input).unwrap_or_default();
+                                info!(step, tool = %name, args = %truncate_tail(&args, 200), "agent tool_use");
+                            }
+                            ContentBlock::Other => {}
+                        }
+                    }
+                }
+            }
+            "tool" => {
+                if let Some(content) = &parsed.content {
+                    let s = match content {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => serde_json::to_string(other).unwrap_or_default(),
+                    };
+                    debug!(step, result = %truncate_tail(&s, 300), "tool result");
+                }
+            }
+            "result" => {
+                info!(
+                    step,
+                    turns = parsed.num_turns.unwrap_or(0),
+                    cost_usd = parsed.total_cost_usd.unwrap_or(0.0),
+                    is_error = parsed.is_error.unwrap_or(false),
+                    "agent finished"
+                );
+            }
+            _ => {}
+        }
     }
 }
 
@@ -64,7 +182,8 @@ pub async fn plan(
     );
 
     info!("creating task plan");
-    let result = sandbox.exec(&agent_cmd(agent, &instruction)).await?;
+    let result = sandbox.exec(&agent_cmd(agent, &instruction, true)).await?;
+    log_trajectory(&result.stdout, "Plan");
     check_exec(&result, "Plan")?;
 
     let task_list = sandbox.read_file("/app/tasks.md").await?;
@@ -119,7 +238,8 @@ pub async fn work(sandbox: &mut impl Sandbox, agent: &AgentConfig, language: &st
     );
 
     info!("working on unchecked tasks");
-    let result = sandbox.exec(&agent_cmd(agent, &instruction)).await?;
+    let result = sandbox.exec(&agent_cmd(agent, &instruction, true)).await?;
+    log_trajectory(&result.stdout, "Work");
     check_exec(&result, "Work")?;
     Ok(())
 }
@@ -177,15 +297,7 @@ pub async fn review(sandbox: &mut impl Sandbox, agent: &AgentConfig, language: &
     );
 
     info!("reviewing code");
-    let result = sandbox.exec(&agent_cmd(agent, &instruction)).await?;
-    debug!(
-        stdout_len = result.stdout.len(),
-        stderr_len = result.stderr.len(),
-        exit_code = result.exit_code,
-        stdout_head = %truncate(&result.stdout, 500),
-        stderr_head = %truncate(&result.stderr, 500),
-        "review raw output"
-    );
+    let result = sandbox.exec(&agent_cmd(agent, &instruction, false)).await?;
     check_exec(&result, "Review")?;
 
     let output = result.stdout.trim().to_string();


### PR DESCRIPTION
## Summary
- Add trajectory logging for plan/work steps via Claude's `--output-format stream-json --verbose` — logs every tool call, text response, turns and cost
- Full untruncated stdout/stderr on step failures for debuggability
- Custom host path mounts (`[[mounts]]` in forge.toml)
- Claude install caching (reuse existing binary instead of re-downloading)
- Dagger timeout bump 600s → 3600s for parallel runs
- Improved forge-command.md with task DAG decomposition protocol

## Test plan
- [x] Tested happy path (simple Rust project) — trajectory logs show tool calls and cost
- [x] Tested broken env (bazel not installed) — failure logs show full agent reasoning and clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)