### PR TITLE
bump opencode to 1.2.15 for skill support

### DIFF
--- a/klaudbiusz/Dockerfile
+++ b/klaudbiusz/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://bun.sh/install | bash && \
 
 # install opencode CLI (copy binary to system path)
 # pin version to avoid flaky version API
-RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.0.180 && \
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.2.15 && \
     cp /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     rm -rf /root/.opencode
 


### PR DESCRIPTION
## Summary
- Bumps OpenCode from 1.0.180 to 1.2.15 in Dockerfile
- v1.0.180 predates the native `skill` tool (added in v1.0.190), so OpenCode agents never discovered or used databricks-apps/databricks skills despite them being correctly mounted
- Verified: with 1.2.15, OpenCode calls `skill({"name":"databricks-apps"})` and `skill({"name":"databricks"})` successfully

## Test plan
- [x] Ran single_run.py with `--backend=opencode` — skills loaded correctly
- [ ] Full bulk run with OpenCode backend to verify appkit usage in generated apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)