### PR TITLE
Fix release-download references to use neondatabase/appdotbuild-agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ cargo run --manifest-path edda_mcp/Cargo.toml
 cargo test
 
 # Install MCP server locally
-curl -LsSf https://raw.githubusercontent.com/appdotbuild/agent/refs/heads/main/edda/install.sh | sh
+curl -LsSf https://raw.githubusercontent.com/neondatabase/appdotbuild-agent/refs/heads/main/edda/install.sh | sh
 ```
 
 ### Core Patterns

--- a/agent/laravel_agent/application.py
+++ b/agent/laravel_agent/application.py
@@ -311,7 +311,7 @@ class FSMApplication:
         return actions
 
     async def get_diff_with(self, snapshot: dict[str, str]) -> str:
-        # TODO: Filter out binary files from diffs - https://github.com/appdotbuild/agent/issues/247
+        # TODO: Filter out binary files from diffs - https://github.com/neondatabase/appdotbuild-agent/issues/247
         logger.info(
             f"SERVER get_diff_with: Received snapshot with {len(snapshot)} files."
         )

--- a/edda/edda_mcp/src/version_check.rs
+++ b/edda/edda_mcp/src/version_check.rs
@@ -1,7 +1,8 @@
 use eyre::Result;
 use serde::Deserialize;
 
-const GITHUB_API_URL: &str = "https://api.github.com/repos/appdotbuild/agent/releases/latest";
+const GITHUB_API_URL: &str =
+    "https://api.github.com/repos/neondatabase/appdotbuild-agent/releases/latest";
 
 #[derive(Debug, Deserialize)]
 struct GitHubRelease {
@@ -40,7 +41,7 @@ pub async fn check_for_updates() -> Result<()> {
     match compare_versions(current, &latest)? {
         std::cmp::Ordering::Less => {
             eprintln!(
-                "\n📦 Update available: v{} → v{}\n   Run: curl -LsSf https://raw.githubusercontent.com/appdotbuild/agent/refs/heads/main/edda/install.sh | sh\n",
+                "\n📦 Update available: v{} → v{}\n   Run: curl -LsSf https://raw.githubusercontent.com/neondatabase/appdotbuild-agent/refs/heads/main/edda/install.sh | sh\n",
                 current, latest
             );
         }

--- a/edda/install.sh
+++ b/edda/install.sh
@@ -8,7 +8,7 @@
 set -u
 
 APP_NAME="edda_mcp"
-GITHUB_REPO="appdotbuild/agent"
+GITHUB_REPO="neondatabase/appdotbuild-agent"
 GITHUB_BASE_URL="https://github.com/${GITHUB_REPO}"
 
 # Version handling - support EDDA_VERSION env var

--- a/klaudbiusz/cli/setup.py
+++ b/klaudbiusz/cli/setup.py
@@ -17,7 +17,7 @@ import fire
 def main(
     clone_to: str | None = None,
     install_deps: bool = True,
-    git_url: str = "https://github.com/appdotbuild/agent.git",
+    git_url: str = "https://github.com/neondatabase/appdotbuild-agent.git",
     branch: str = "main",
 ) -> None:
     """Self-setup klaudbiusz in a new environment.


### PR DESCRIPTION
## Problem

`edda/install.sh` hardcodes `GITHUB_REPO="appdotbuild/agent"`, but the release binaries are published under **`neondatabase/appdotbuild-agent`** (where this repo lives). Every download URL therefore 404s and the install fails (issue #763):

```
appdotbuild/agent/releases/latest/download/edda_mcp-macos-arm64        -> 404
neondatabase/appdotbuild-agent/releases/latest/download/edda_mcp-...   -> 200
```

The same root cause — release artifacts live under `neondatabase/appdotbuild-agent`, not `appdotbuild/agent` — affects more than just the installer. `appdotbuild/agent` is now a stale mirror (last pushed 2026-03-19, **no releases**), so its release-download URLs 404 and its raw/issue links are outdated.

## Fix

Repoint every `appdotbuild/agent` GitHub reference to `neondatabase/appdotbuild-agent`:

| File | Reference | Effect |
|------|-----------|--------|
| `edda/install.sh` | `GITHUB_REPO` | the reported 404 — release downloads now resolve |
| `edda/edda_mcp/src/version_check.rs` | release API URL + update-hint curl URL | the binary's auto-update check no longer 404s |
| `CLAUDE.md` | local-install curl URL | docs point at the live repo |
| `klaudbiusz/cli/setup.py` | self-setup git clone URL | clone targets the canonical repo |
| `agent/laravel_agent/application.py` | TODO issue link (#247) | link was 404 on the mirror; now resolves |

**Intentionally unchanged:** `ECR_REPOSITORY: appdotbuild/agent-fullstack` in `.github/workflows/python.yml` — that's an AWS ECR registry path, not a GitHub repo.

## Verification

- `appdotbuild/agent/releases/latest` → 404; `neondatabase/appdotbuild-agent` → `v0.0.10` with `edda_mcp-macos-arm64` / `edda_mcp-linux-x86_64` assets (HTTP 200).
- `rustfmt --check` clean on `version_check.rs`; `sh -n` clean on `install.sh`; `setup.py` compiles.

Fixes #763

This pull request and its description were written by Isaac.